### PR TITLE
fix(ci): set profile to test for clippy and test jobs to reuse cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           shared-key: "all-targets-profile-test"
           save-if: false # Restore only
       - name: Run clippy
-        run: cargo clippy --workspace --all-targets --no-deps -- --deny warnings
+        run: cargo clippy --workspace --all-targets --profile test --no-deps -- --deny warnings
 
   test:
     needs: build
@@ -57,4 +57,4 @@ jobs:
           shared-key: "all-targets-profile-test"
           save-if: false # Restore only
       - name: Run tests
-        run: cargo test --workspace
+        run: cargo test --workspace --profile test


### PR DESCRIPTION
## Context

Cargo stores build artifacts separately for each profile, so to reuse cached build results, you need to specify `--profile test` and ensure that all jobs use the same profile.

## Changes

- Set profile to `test` for lint and test jobs