### PR TITLE
[イベントバス] イベントバスのpublisherとsubscription定義

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,10 @@ name = "monas-contents"
 version = "0.1.0"
 
 [[package]]
+name = "monas-event-manager"
+version = "0.1.0"
+
+[[package]]
 name = "once_cell"
 version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["monas-account", "monas-contents"]
+members = ["monas-account", "monas-contents", "monas-event-manager"]
 resolver = "2"
 
 [workspace.package]

--- a/monas-event-manager/Cargo.toml
+++ b/monas-event-manager/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "monas-event-manager"
+authors.workspace = true
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]

--- a/monas-event-manager/src/event_bus/event_bus.rs
+++ b/monas-event-manager/src/event_bus/event_bus.rs
@@ -40,11 +40,11 @@ impl EventBus {
 
 #[cfg(test)]
 mod event_bus_tests {
+    use crate::event_bus::event_bus::EventBus;
+    use crate::event_subscription::event_subscription::{make_subscriber, EventSubscriptions};
     use std::any::TypeId;
     use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
-    use crate::event_bus::event_bus::EventBus;
-    use crate::event_subscription::event_subscription::{make_subscriber, EventSubscriptions};
 
     #[test]
     fn publish_subscriptions_test() {
@@ -78,7 +78,9 @@ mod event_bus_tests {
             ],
         );
 
-        let publisher = EventBus { event_subscriptions: subscriptions };
+        let publisher = EventBus {
+            event_subscriptions: subscriptions,
+        };
 
         publisher.publish(&event1);
 
@@ -120,13 +122,15 @@ mod event_bus_tests {
 
         subscriptions.add_subscribers(
             TypeId::of::<TestMessageEvent2>(),
-            vec![        make_subscriber(move |test_event: &TestMessageEvent2| {
+            vec![make_subscriber(move |test_event: &TestMessageEvent2| {
                 let mut ev_message2 = shared_str2.lock().unwrap();
                 *ev_message2 = format!("fire1: {}", test_event.message.to_string())
             })],
         );
 
-        let publisher = EventBus { event_subscriptions: subscriptions };
+        let publisher = EventBus {
+            event_subscriptions: subscriptions,
+        };
 
         let result1 = publisher.publish(&event1);
 
@@ -157,7 +161,6 @@ mod event_bus_tests {
 
         let event2 = TestMessageEvent2 { message: "test 2" };
 
-
         subscriptions.add_subscribers(
             TypeId::of::<TestMessageEvent1>(),
             vec![make_subscriber(move |test_event: &TestMessageEvent1| {
@@ -165,7 +168,9 @@ mod event_bus_tests {
             })],
         );
 
-        let publisher = EventBus { event_subscriptions: subscriptions };
+        let publisher = EventBus {
+            event_subscriptions: subscriptions,
+        };
 
         let result = publisher.publish(&event2);
 

--- a/monas-event-manager/src/event_bus/event_bus.rs
+++ b/monas-event-manager/src/event_bus/event_bus.rs
@@ -1,0 +1,39 @@
+use crate::event_subscription::event_subscription::EventSubscriptions;
+use std::any::Any;
+
+// publisher側はこの型を継承してね
+pub trait Event: Any {
+    fn as_any(&self) -> &dyn Any;
+}
+
+impl<T: Any> Event for T {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+// イベント処理
+pub struct EventBus {
+    event_subscriptions: EventSubscriptions,
+}
+
+impl EventBus {
+    pub fn initialize(event_subscriptions: EventSubscriptions) -> Self {
+        Self {
+            event_subscriptions: event_subscriptions,
+        }
+    }
+
+    fn publish(&self, event: &dyn Event) -> Option<()> {
+        let type_id = event.as_any().type_id();
+        if let Some(subscribers) = self.event_subscriptions.get_subscriptions().get(&type_id) {
+            for subscriber in subscribers {
+                subscriber.subscriber()(event);
+            }
+            Some(())
+        } else {
+            eprintln!("No subscribers found for event type: {:?}", type_id);
+            None
+        }
+    }
+}

--- a/monas-event-manager/src/event_bus/event_bus.rs
+++ b/monas-event-manager/src/event_bus/event_bus.rs
@@ -12,7 +12,7 @@ impl<T: Any> Event for T {
     }
 }
 
-// イベント処理
+/// イベント処理: TODO 命名は要検討
 pub struct EventBus {
     event_subscriptions: EventSubscriptions,
 }
@@ -35,5 +35,140 @@ impl EventBus {
             eprintln!("No subscribers found for event type: {:?}", type_id);
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod event_bus_tests {
+    use std::any::TypeId;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+    use crate::event_bus::event_bus::EventBus;
+    use crate::event_subscription::event_subscription::{make_subscriber, EventSubscriptions};
+
+    #[test]
+    fn publish_subscriptions_test() {
+        struct TestMessageEvent {
+            message: &'static str,
+        }
+
+        let shared_str1 = Arc::new(Mutex::new(String::from("")));
+        let shared_str_clone1 = Arc::clone(&shared_str1);
+
+        let shared_str2 = Arc::new(Mutex::new(String::from("")));
+        let shared_str_clone2 = Arc::clone(&shared_str2);
+
+        let mut subscriptions = EventSubscriptions {
+            subscriptions: HashMap::new(),
+        };
+
+        let event1 = TestMessageEvent { message: "test" };
+
+        subscriptions.add_subscribers(
+            TypeId::of::<TestMessageEvent>(),
+            vec![
+                make_subscriber(move |test_event: &TestMessageEvent| {
+                    let mut ev_message1 = shared_str1.lock().unwrap();
+                    *ev_message1 = format!("fire1: {}", test_event.message.to_string())
+                }),
+                make_subscriber(move |test_event: &TestMessageEvent| {
+                    let mut ev_message2 = shared_str2.lock().unwrap();
+                    *ev_message2 = format!("fire2: {}", test_event.message.to_string())
+                }),
+            ],
+        );
+
+        let publisher = EventBus { event_subscriptions: subscriptions };
+
+        publisher.publish(&event1);
+
+        assert_eq!(*shared_str_clone1.lock().unwrap(), "fire1: test");
+        assert_eq!(*shared_str_clone2.lock().unwrap(), "fire2: test");
+    }
+
+    #[test]
+    fn publish_all_event_test() {
+        struct TestMessageEvent1 {
+            message: &'static str,
+        }
+
+        struct TestMessageEvent2 {
+            message: &'static str,
+        }
+
+        let shared_str1 = Arc::new(Mutex::new(String::from("")));
+        let shared_str_clone1 = Arc::clone(&shared_str1);
+
+        let shared_str2 = Arc::new(Mutex::new(String::from("")));
+        let shared_str_clone2 = Arc::clone(&shared_str2);
+
+        let mut subscriptions = EventSubscriptions {
+            subscriptions: HashMap::new(),
+        };
+
+        let event1 = TestMessageEvent1 { message: "test 1" };
+
+        let event2 = TestMessageEvent2 { message: "test 2" };
+
+        subscriptions.add_subscribers(
+            TypeId::of::<TestMessageEvent1>(),
+            vec![make_subscriber(move |test_event: &TestMessageEvent1| {
+                let mut ev_message1 = shared_str1.lock().unwrap();
+                *ev_message1 = format!("fire1: {}", test_event.message.to_string())
+            })],
+        );
+
+        subscriptions.add_subscribers(
+            TypeId::of::<TestMessageEvent2>(),
+            vec![        make_subscriber(move |test_event: &TestMessageEvent2| {
+                let mut ev_message2 = shared_str2.lock().unwrap();
+                *ev_message2 = format!("fire1: {}", test_event.message.to_string())
+            })],
+        );
+
+        let publisher = EventBus { event_subscriptions: subscriptions };
+
+        let result1 = publisher.publish(&event1);
+
+        assert_eq!(*shared_str_clone1.lock().unwrap(), "fire1: test 1");
+
+        let result2 = publisher.publish(&event2);
+        assert_eq!(*shared_str_clone2.lock().unwrap(), "fire1: test 2");
+
+        assert_eq!(result1, Some(()));
+        assert_eq!(result2, Some(()));
+    }
+
+    #[test]
+    fn publish_failure_test() {
+        struct TestMessageEvent1 {
+            message: &'static str,
+        }
+
+        struct TestMessageEvent2 {
+            message: &'static str,
+        }
+
+        let mut subscriptions = EventSubscriptions {
+            subscriptions: HashMap::new(),
+        };
+
+        let event1 = TestMessageEvent1 { message: "test 1" };
+
+        let event2 = TestMessageEvent2 { message: "test 2" };
+
+
+        subscriptions.add_subscribers(
+            TypeId::of::<TestMessageEvent1>(),
+            vec![make_subscriber(move |test_event: &TestMessageEvent1| {
+                println!("empty");
+            })],
+        );
+
+        let publisher = EventBus { event_subscriptions: subscriptions };
+
+        let result = publisher.publish(&event2);
+
+        assert!(result.is_none());
     }
 }

--- a/monas-event-manager/src/event_bus/mod.rs
+++ b/monas-event-manager/src/event_bus/mod.rs
@@ -1,0 +1,1 @@
+pub mod event_bus;

--- a/monas-event-manager/src/event_subscription/event_subscription.rs
+++ b/monas-event-manager/src/event_subscription/event_subscription.rs
@@ -1,5 +1,5 @@
 use crate::event_bus::event_bus::Event;
-use std::any::{Any, TypeId};
+use std::any::TypeId;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -72,6 +72,5 @@ where
 
     Subscriber::new(wrapped)
 }
-
 
 //TODO test

--- a/monas-event-manager/src/event_subscription/event_subscription.rs
+++ b/monas-event-manager/src/event_subscription/event_subscription.rs
@@ -1,0 +1,169 @@
+use crate::event_bus::event_bus::Event;
+use std::any::{Any, TypeId};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+pub type SubscribeFn = Arc<dyn Fn(&dyn Event) + Send + Sync>;
+pub type Subscribers = Vec<Subscriber>;
+
+pub struct EventSubscriptions {
+    subscriptions: HashMap<TypeId, Subscribers>,
+}
+
+/// イベントと購読ハンドラのマッピング管理
+impl EventSubscriptions {
+    pub fn new() -> Self {
+        Self {
+            subscriptions: HashMap::new(),
+        }
+    }
+
+    pub fn get_subscriptions(&self) -> &HashMap<TypeId, Subscribers> {
+        &self.subscriptions
+    }
+
+    /// 指定した TypeId に対応する Subscribers を返す
+    pub fn lookup_subscribers(&self, lookup: &TypeId) -> Option<&Subscribers> {
+        self.subscriptions.get(lookup)
+    }
+
+    /// 指定した TypeId に対応する Subscribersを渡す
+    pub fn add_subscribers(&mut self, type_id: TypeId, subscribers: Subscribers) {
+        self.subscriptions.insert(type_id, subscribers);
+    }
+}
+
+// Subscriber の定義
+pub struct Subscriber {
+    subscriber: Option<SubscribeFn>,
+}
+
+impl Subscriber {
+    pub fn new<F>(handler: F) -> Self
+    where
+        F: Fn(&dyn Event) + Send + Sync + 'static,
+    {
+        Self {
+            subscriber: Some(Arc::new(handler)),
+        }
+    }
+
+    pub fn subscriber(&self) -> SubscribeFn {
+        self.subscriber
+            .as_ref()
+            .expect("No subscriber function found")
+            .clone()
+    }
+}
+
+/// 型特有のハンドラを生成するユーティリティ関数
+pub fn make_subscriber<T, F>(handler: F) -> Subscriber
+where
+    T: Event + 'static,
+    F: Fn(&T) + Send + Sync + 'static,
+{
+    let wrapped = move |event: &dyn Event| {
+        if let Some(specific) = event.as_any().downcast_ref::<T>() {
+            handler(specific);
+        } else {
+            eprintln!("Received event of unexpected type");
+        }
+    };
+
+    Subscriber::new(wrapped)
+}
+
+#[cfg(test)]
+mod event_subscription_tests {
+    use std::any::TypeId;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    use crate::event_subscription::event_subscription::{make_subscriber, EventSubscriptions};
+
+    #[test]
+    fn dispatch_subscriptions_test() {
+        struct TestMessageEvent {
+            message: &'static str,
+        }
+
+        let shared_str1 = Arc::new(Mutex::new(String::from("")));
+        let shared_str_clone1 = Arc::clone(&shared_str1);
+
+        let shared_str2 = Arc::new(Mutex::new(String::from("")));
+        let shared_str_clone2 = Arc::clone(&shared_str2);
+
+        let mut subscriptions = EventSubscriptions {
+            subscriptions: HashMap::new(),
+        };
+
+        let event1 = TestMessageEvent { message: "test" };
+
+        subscriptions.add_subscribers(
+            TypeId::of::<TestMessageEvent>(),
+            vec![
+                make_subscriber(move |test_event: &TestMessageEvent| {
+                    let mut ev_message1 = shared_str1.lock().unwrap();
+                    *ev_message1 = format!("fire1: {}", test_event.message.to_string())
+                }),
+                make_subscriber(move |test_event: &TestMessageEvent| {
+                    let mut ev_message2 = shared_str2.lock().unwrap();
+                    *ev_message2 = format!("fire2: {}", test_event.message.to_string())
+                }),
+            ],
+        );
+
+        subscriptions.dispatch(&event1);
+
+        assert_eq!(*shared_str_clone1.lock().unwrap(), "fire1: test");
+        assert_eq!(*shared_str_clone2.lock().unwrap(), "fire2: test");
+    }
+
+    #[test]
+    fn dispatch_all_events_test() {
+        struct TestMessageEvent1 {
+            message: &'static str,
+        }
+
+        struct TestMessageEvent2 {
+            message: &'static str,
+        }
+
+        let shared_str1 = Arc::new(Mutex::new(String::from("")));
+        let shared_str_clone1 = Arc::clone(&shared_str1);
+
+        let shared_str2 = Arc::new(Mutex::new(String::from("")));
+        let shared_str_clone2 = Arc::clone(&shared_str2);
+
+        let mut subscriptions = EventSubscriptions {
+            subscriptions: HashMap::new(),
+        };
+
+        let event1 = TestMessageEvent1 { message: "test 1" };
+
+        let event2 = TestMessageEvent2 { message: "test 2" };
+
+        subscriptions.add_subscribers(
+            TypeId::of::<TestMessageEvent1>(),
+            vec![make_subscriber(move |test_event: &TestMessageEvent1| {
+                let mut ev_message1 = shared_str1.lock().unwrap();
+                *ev_message1 = format!("fire1: {}", test_event.message.to_string())
+            })],
+        );
+
+        subscriptions.add_subscribers(
+            TypeId::of::<TestMessageEvent2>(),
+            vec![make_subscriber(move |test_event: &TestMessageEvent2| {
+                let mut ev_message2 = shared_str2.lock().unwrap();
+                *ev_message2 = format!("fire1: {}", test_event.message.to_string())
+            })],
+        );
+
+        subscriptions.dispatch(&event1);
+
+        assert_eq!(*shared_str_clone1.lock().unwrap(), "fire1: test 1");
+
+        subscriptions.dispatch(&event2);
+        assert_eq!(*shared_str_clone2.lock().unwrap(), "fire1: test 2");
+    }
+}

--- a/monas-event-manager/src/event_subscription/mod.rs
+++ b/monas-event-manager/src/event_subscription/mod.rs
@@ -1,0 +1,1 @@
+pub mod event_subscription;

--- a/monas-event-manager/src/main.rs
+++ b/monas-event-manager/src/main.rs
@@ -1,0 +1,6 @@
+mod event_bus;
+mod event_subscription;
+
+fn main() {
+    println!("Hello, world!");
+}

--- a/structure.md
+++ b/structure.md
@@ -1,0 +1,22 @@
+.
+├── Cargo.lock
+├── Cargo.toml
+├── LICENSE
+├── monas-account
+│   ├── Cargo.toml
+│   ├── rustfmt.toml
+│   └── src
+│       ├── application_service
+│       ├── domain
+│       ├── infrastructure
+│       ├── lib.rs
+│       └── presentation
+├── monas-contents
+│   ├── Cargo.toml
+│   └── src
+│       └── lib.rs
+├── src
+│   └── main.rs
+└── structure.md
+
+10 directories, 10 files


### PR DESCRIPTION
## 用語
Publisher -> イベントを送付する人
Subscriber -> イベントを購読する人
Subscription -> イベントと購読者のマッピング

## 実装方針
WASMへの対応を考え、シングルスレッド向けに同期的なイベントバスを定義する。

## EventSubscriptions
イベントと購読者(Subscriber)を繋ぐ概念としてSubscriptionを定義した。
EventSubscriptionsはイベントに対してマッピングされた購読者を示す構造体。

###イベント登録
EventSubscriptionsが公開するadd_subscribersを利用してマッピングを追加する。

### Subscriber
イベントを受け取った際に発火する、購読者側のハンドラ定義。
基本的にイベントがPublishされた場合に受け取る側のエントリポイントを実行する。

## Draft解除条件
- テスト書く
- Routerの概念などを整理する(Subscriberのハンドラ定義やエントリポイントなどが足りない)
- 命名が微妙なので修正する。