### PR TITLE
[Account] fix invalid account domain dependency

### DIFF
--- a/monas-account/src/application_service/account_service.rs
+++ b/monas-account/src/application_service/account_service.rs
@@ -33,7 +33,7 @@ impl AccountService {
 mod account_application_tests {
     use crate::application_service::account_service::{AccountService, KeyTypeMapper};
     use crate::infrastructure::key_pair::KeyAlgorithm::K256;
-    use crate::infrastructure::key_pair::{KeyPairGenerateFactory};
+    use crate::infrastructure::key_pair::KeyPairGenerateFactory;
 
     #[test]
     fn create_account() {

--- a/monas-account/src/application_service/account_service.rs
+++ b/monas-account/src/application_service/account_service.rs
@@ -38,10 +38,10 @@ mod account_application_tests {
     #[test]
     fn create_account() {
         let account = AccountService::create(KeyTypeMapper::K256).unwrap();
-        let expected = KeyPairGenerateFactory::generate(K256).public_key_bytes();
+        let generated = KeyPairGenerateFactory::generate(K256);
+        let expected = generated.public_key_bytes();
 
-        let is_created_key_type = matches!(account.keypair().public_key_bytes(), expected);
-        assert!(is_created_key_type);
+        assert_eq!(account.keypair().public_key_bytes(), expected);
         assert!(!account.is_deleted());
     }
 }

--- a/monas-account/src/domain/account.rs
+++ b/monas-account/src/domain/account.rs
@@ -19,7 +19,10 @@ impl Account {
         }
     }
 
-    pub fn regenerate_keypair(&self, key_pair: Box<dyn AccountKeyPair>) -> Result<Account, AccountError> {
+    pub fn regenerate_keypair(
+        &self,
+        key_pair: Box<dyn AccountKeyPair>,
+    ) -> Result<Account, AccountError> {
         if self.deleted {
             return Err(AccountError::AccountAlreadyDeleted);
         }
@@ -51,12 +54,11 @@ pub trait AccountKeyPair: Send + Sync {
     fn secret_key_bytes(&self) -> &[u8];
 }
 
-
 #[cfg(test)]
 mod account_tests {
-    use crate::infrastructure::key_pair::KeyAlgorithm::K256;
-    use crate::infrastructure::key_pair::{KeyPairGenerateFactory};
     use super::*;
+    use crate::infrastructure::key_pair::KeyAlgorithm::K256;
+    use crate::infrastructure::key_pair::KeyPairGenerateFactory;
 
     #[test]
     fn regenerate_key_pair() {
@@ -64,7 +66,9 @@ mod account_tests {
 
         let key_pair_before = account.key_pair.public_key_bytes().clone();
 
-        account.regenerate_keypair(KeyPairGenerateFactory::generate(K256)).unwrap();
+        account
+            .regenerate_keypair(KeyPairGenerateFactory::generate(K256))
+            .unwrap();
 
         let key_pair_after = account.key_pair.public_key_bytes().clone();
 
@@ -79,9 +83,7 @@ mod account_tests {
 
         account.delete().unwrap();
         assert!(account.is_deleted());
-        let result = account.regenerate_keypair(
-            KeyPairGenerateFactory::generate(K256),
-        );
+        let result = account.regenerate_keypair(KeyPairGenerateFactory::generate(K256));
         matches!(result, Err(AccountError::AccountAlreadyDeleted));
     }
 

--- a/monas-account/src/domain/account.rs
+++ b/monas-account/src/domain/account.rs
@@ -64,13 +64,13 @@ mod account_tests {
     fn regenerate_key_pair() {
         let account = Account::init(KeyPairGenerateFactory::generate(K256));
 
-        let key_pair_before = account.key_pair.public_key_bytes().clone();
+        let key_pair_before = account.key_pair.public_key_bytes();
 
         account
             .regenerate_keypair(KeyPairGenerateFactory::generate(K256))
             .unwrap();
 
-        let key_pair_after = account.key_pair.public_key_bytes().clone();
+        let key_pair_after = account.key_pair.public_key_bytes();
 
         assert!(!key_pair_before.eq(key_pair_after));
 

--- a/monas-account/src/domain/account.rs
+++ b/monas-account/src/domain/account.rs
@@ -1,4 +1,3 @@
-use crate::infrastructure::key_pair::KeyPair;
 
 #[derive(Clone, PartialEq)]
 pub struct Account {
@@ -45,10 +44,17 @@ impl Account {
     }
 }
 
+pub trait AccountKeyPair {
+    fn sign(&self, msg: &[u8]) -> (Vec<u8>, Option<u8>);
+    fn public_key_bytes(&self) -> &[u8];
+
+    fn secret_key_bytes(&self) -> &[u8];
+}
+
+
 #[cfg(test)]
 mod account_tests {
     use super::*;
-    use crate::infrastructure::key_pair::KeyType::K256;
 
     #[test]
     fn regenerate_key_pair() {

--- a/monas-account/src/infrastructure/key_pair.rs
+++ b/monas-account/src/infrastructure/key_pair.rs
@@ -1,10 +1,10 @@
 pub mod k256_key_pair;
 pub mod p256_key_pair;
 
+use crate::domain::account::AccountKeyPair;
 use crate::infrastructure::key_pair::k256_key_pair::K256KeyPair;
 use crate::infrastructure::key_pair::p256_key_pair::P256KeyPair;
 use std::fmt::Debug;
-use crate::domain::account::AccountKeyPair;
 
 #[derive(Clone, PartialEq)]
 pub enum KeyPair {
@@ -34,9 +34,9 @@ impl KeyPairGenerateFactory {
 #[cfg(test)]
 mod key_pair_tests {
     use crate::domain::account::AccountKeyPair;
-    use crate::infrastructure::key_pair::{KeyPairGenerateFactory, KeyAlgorithm};
     use crate::infrastructure::key_pair::k256_key_pair::K256KeyPair;
     use crate::infrastructure::key_pair::p256_key_pair::P256KeyPair;
+    use crate::infrastructure::key_pair::{KeyAlgorithm, KeyPairGenerateFactory};
 
     #[test]
     fn key_pair_k256_generate_test() {

--- a/monas-account/src/infrastructure/key_pair.rs
+++ b/monas-account/src/infrastructure/key_pair.rs
@@ -4,6 +4,7 @@ pub mod p256_key_pair;
 use crate::infrastructure::key_pair::k256_key_pair::K256KeyPair;
 use crate::infrastructure::key_pair::p256_key_pair::P256KeyPair;
 use std::fmt::Debug;
+use crate::domain::account::AccountKeyPair;
 
 #[derive(Clone, PartialEq)]
 pub enum KeyPair {
@@ -14,33 +15,42 @@ pub enum KeyPair {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum KeyType {
+pub enum KeyAlgorithm {
     K256,
     P256,
 }
 
-impl KeyPair {
-    pub fn generate(key_type: KeyType) -> KeyPair {
+pub struct KeyPairGenerateFactory;
+
+impl KeyPairGenerateFactory {
+    pub fn generate(key_type: KeyAlgorithm) -> Box<dyn AccountKeyPair> {
         match key_type {
-            KeyType::K256 => KeyPair::K256KeyPair(K256KeyPair::generate()),
-            KeyType::P256 => KeyPair::P256KeyPair(P256KeyPair::generate()),
+            KeyAlgorithm::K256 => Box::new(K256KeyPair::generate()),
+            KeyAlgorithm::P256 => Box::new(P256KeyPair::generate()),
         }
     }
 }
 
 #[cfg(test)]
 mod key_pair_tests {
-    use crate::infrastructure::key_pair::{KeyPair, KeyType};
+    use crate::domain::account::AccountKeyPair;
+    use crate::infrastructure::key_pair::{KeyPairGenerateFactory, KeyAlgorithm};
+    use crate::infrastructure::key_pair::k256_key_pair::K256KeyPair;
+    use crate::infrastructure::key_pair::p256_key_pair::P256KeyPair;
 
     #[test]
     fn key_pair_k256_generate_test() {
-        let k256 = KeyPair::generate(KeyType::K256);
-        assert!(matches!(k256, KeyPair::K256KeyPair(_)));
+        let k256 = KeyPairGenerateFactory::generate(KeyAlgorithm::K256);
+        let key_pair = K256KeyPair::generate();
+        let key_pair_to_byte = key_pair.public_key_bytes();
+        assert_eq!(k256.public_key_bytes(), key_pair_to_byte);
     }
 
     #[test]
     fn key_pair_p256_generate_test() {
-        let p256 = KeyPair::generate(KeyType::P256);
-        assert!(matches!(p256, KeyPair::P256KeyPair(_)));
+        let p256 = KeyPairGenerateFactory::generate(KeyAlgorithm::P256);
+        let key_pair = P256KeyPair::generate();
+        let key_pair_to_byte = key_pair.public_key_bytes();
+        assert_eq!(p256.public_key_bytes(), key_pair_to_byte);
     }
 }

--- a/monas-account/src/infrastructure/key_pair/k256_key_pair.rs
+++ b/monas-account/src/infrastructure/key_pair/k256_key_pair.rs
@@ -9,7 +9,6 @@ use sha3::Keccak256;
 #[derive(Clone)]
 pub struct K256KeyPair {
     secret_key: SigningKey,
-    public_key: VerifyingKey,
     public_key_point: EncodedPoint,
     secret_key_field_key: FieldBytes,
 }
@@ -22,7 +21,6 @@ impl K256KeyPair {
         let secret_key_field_key = secret_key.to_bytes();
         K256KeyPair {
             secret_key,
-            public_key,
             public_key_point,
             secret_key_field_key,
         }
@@ -76,7 +74,7 @@ mod k256_key_pair_tests {
         let (sig_bytes, _rec_id) = k256.sign(message);
 
         let signature =
-            Signature::from_slice(&sig_bytes.as_slice()).expect("invalid signature bytes");
+            Signature::from_slice(sig_bytes.as_slice()).expect("invalid signature bytes");
 
         let verifying_key = VerifyingKey::from_sec1_bytes(k256.public_key_bytes())
             .expect("invalid public key bytes");

--- a/monas-account/src/infrastructure/key_pair/k256_key_pair.rs
+++ b/monas-account/src/infrastructure/key_pair/k256_key_pair.rs
@@ -37,10 +37,7 @@ impl PartialEq for K256KeyPair {
 }
 
 impl AccountKeyPair for K256KeyPair {
-    type Signature = Signature;
-    type RecoveryId = RecoveryId;
-
-    fn sign(&self, message: &[u8]) -> (Self::Signature, Self::RecoveryId) {
+    fn sign(&self, message: &[u8]) -> (Vec<u8>, Option<u8>) {
         self.secret_key
             .sign_digest(Keccak256::new_with_prefix(message));
     }

--- a/monas-account/src/infrastructure/key_pair/k256_key_pair.rs
+++ b/monas-account/src/infrastructure/key_pair/k256_key_pair.rs
@@ -1,10 +1,10 @@
+use crate::domain::account::AccountKeyPair;
+use k256::ecdsa::signature::DigestSigner;
 use k256::ecdsa::{SigningKey, VerifyingKey};
 use k256::elliptic_curve::rand_core::OsRng;
-use k256::{EncodedPoint, FieldBytes};
-use k256::ecdsa::signature::DigestSigner;
 use k256::sha2::Digest;
+use k256::{EncodedPoint, FieldBytes};
 use sha3::Keccak256;
-use crate::domain::account::AccountKeyPair;
 
 #[derive(Clone)]
 pub struct K256KeyPair {
@@ -24,7 +24,7 @@ impl K256KeyPair {
             secret_key,
             public_key,
             public_key_point,
-            secret_key_field_key
+            secret_key_field_key,
         }
     }
 }
@@ -37,7 +37,8 @@ impl PartialEq for K256KeyPair {
 
 impl AccountKeyPair for K256KeyPair {
     fn sign(&self, message: &[u8]) -> (Vec<u8>, Option<u8>) {
-        let (signature, recover_id) = self.secret_key
+        let (signature, recover_id) = self
+            .secret_key
             .sign_digest(Keccak256::new_with_prefix(message));
         (signature.to_vec(), Some(recover_id.to_byte()))
     }
@@ -53,11 +54,11 @@ impl AccountKeyPair for K256KeyPair {
 
 #[cfg(test)]
 mod k256_key_pair_tests {
+    use crate::domain::account::AccountKeyPair;
+    use crate::infrastructure::key_pair::k256_key_pair::K256KeyPair;
     use k256::ecdsa::signature::DigestVerifier;
     use k256::ecdsa::{Signature, VerifyingKey};
     use sha3::{Digest, Keccak256};
-    use crate::domain::account::AccountKeyPair;
-    use crate::infrastructure::key_pair::k256_key_pair::K256KeyPair;
 
     #[test]
     fn generate_has_valid_sizes() {
@@ -74,13 +75,14 @@ mod k256_key_pair_tests {
 
         let (sig_bytes, _rec_id) = k256.sign(message);
 
-        let signature = Signature::from_slice(&sig_bytes.as_slice())
-            .expect("invalid signature bytes");
+        let signature =
+            Signature::from_slice(&sig_bytes.as_slice()).expect("invalid signature bytes");
 
         let verifying_key = VerifyingKey::from_sec1_bytes(k256.public_key_bytes())
             .expect("invalid public key bytes");
 
-        verifying_key.verify_digest(Keccak256::new_with_prefix(message), &signature)
+        verifying_key
+            .verify_digest(Keccak256::new_with_prefix(message), &signature)
             .expect("signature should verify");
     }
 

--- a/monas-account/src/infrastructure/key_pair/k256_key_pair.rs
+++ b/monas-account/src/infrastructure/key_pair/k256_key_pair.rs
@@ -1,27 +1,31 @@
-use k256::ecdsa::{SigningKey, VerifyingKey};
+use k256::ecdsa::{RecoveryId, SigningKey, VerifyingKey};
 use k256::elliptic_curve::rand_core::OsRng;
+use k256::{EncodedPoint, FieldBytes};
+use k256::ecdsa::signature::DigestSigner;
+use k256::sha2::Digest;
+use p256::ecdsa::Signature;
+use sha3::Keccak256;
+use crate::domain::account::AccountKeyPair;
 
 #[derive(Clone)]
 pub struct K256KeyPair {
     secret_key: SigningKey,
     public_key: VerifyingKey,
+    public_key_point: EncodedPoint,
+    secret_key_field_key: FieldBytes,
 }
 
 impl K256KeyPair {
-    pub fn secret_key(&self) -> &SigningKey {
-        &self.secret_key
-    }
-
-    pub fn public_key(&self) -> &VerifyingKey {
-        &self.public_key
-    }
-
     pub fn generate() -> K256KeyPair {
         let secret_key = SigningKey::random(&mut OsRng);
         let public_key = VerifyingKey::from(&secret_key);
+        let public_key_point = public_key.to_encoded_point(false);
+        let secret_key_field_key = secret_key.to_bytes();
         K256KeyPair {
             secret_key,
             public_key,
+            public_key_point,
+            secret_key_field_key
         }
     }
 }
@@ -32,40 +36,68 @@ impl PartialEq for K256KeyPair {
     }
 }
 
+impl AccountKeyPair for K256KeyPair {
+    type Signature = Signature;
+    type RecoveryId = RecoveryId;
+
+    fn sign(&self, message: &[u8]) -> (Self::Signature, Self::RecoveryId) {
+        self.secret_key
+            .sign_digest(Keccak256::new_with_prefix(message));
+    }
+
+    fn public_key_bytes(&self) -> &[u8] {
+        self.public_key_point.as_bytes()
+    }
+
+    fn secret_key_bytes(&self) -> &[u8] {
+        self.secret_key_field_key.as_ref()
+    }
+}
+
 #[cfg(test)]
 mod k256_key_pair_tests {
-    use crate::infrastructure::key_pair::{KeyPair, KeyType};
+    use k256::ecdsa::signature::DigestVerifier;
     use k256::ecdsa::VerifyingKey;
+    use sha3::{Digest, Keccak256};
+    use crate::domain::account::AccountKeyPair;
+    use crate::infrastructure::key_pair::k256_key_pair::K256KeyPair;
+    use crate::infrastructure::key_pair::KeyPair::K256KeyPair;
 
     #[test]
-    fn key_pair_k256_generate_test() {
-        let k256 = KeyPair::generate(KeyType::K256);
-        use sha3::{Digest, Keccak256};
-        let target = b"test signature target";
+    fn generate_has_valid_sizes() {
+        let kp = K256KeyPair::generate();
 
-        match k256 {
-            KeyPair::K256KeyPair(k256_key_pair) => {
-                let digest = Keccak256::new_with_prefix(target);
-                let (signature, recovery_id) = k256_key_pair
-                    .secret_key
-                    .sign_digest_recoverable(digest)
-                    .unwrap();
+        assert_eq!(kp.public_key_bytes().len(), 65);
+        assert_eq!(kp.secret_key_bytes().len(), 32);
+    }
 
-                let recovered_key = VerifyingKey::recover_from_digest(
-                    Keccak256::new_with_prefix(target),
-                    &signature,
-                    recovery_id,
-                )
-                .unwrap();
+    #[test]
+    fn sign_and_verify() {
+        let k256 = K256KeyPair::generate();
+        let message = b"test message";
 
-                let encoded_point = k256_key_pair.public_key.to_owned().to_encoded_point(false);
-                let expected_key_bytes = encoded_point.as_bytes();
-                let expected_key = VerifyingKey::from_sec1_bytes(expected_key_bytes).unwrap();
-                assert_eq!(recovered_key, expected_key);
-            }
-            _ => {
-                panic!("not k256 key type");
-            }
-        }
+        let (signature, _) = k256.sign(message);
+
+        // Change to k256::VerifyingKey
+        let verify_key = VerifyingKey::from_sec1_bytes(k256.public_key_bytes()).unwrap();
+        verify_key
+            .verify_digest(Keccak256::new_with_prefix(message), &signature)
+            .unwrap();
+    }
+
+    #[test]
+    fn different_message_gives_different_signature() {
+        let kp = K256KeyPair::generate();
+        let (sig1, _) = kp.sign(b"same");
+        let (sig2, _) = kp.sign(b"different");
+        assert_ne!(sig1, sig2);
+    }
+
+    #[test]
+    fn same_message_gives_same_signature() {
+        let kp = K256KeyPair::generate();
+        let (sig1, _) = kp.sign(b"same");
+        let (sig2, _) = kp.sign(b"same");
+        assert_eq!(sig1, sig2);
     }
 }

--- a/monas-account/src/infrastructure/key_pair/p256_key_pair.rs
+++ b/monas-account/src/infrastructure/key_pair/p256_key_pair.rs
@@ -25,9 +25,6 @@ impl P256KeyPair {
 }
 
 impl AccountKeyPair for P256KeyPair {
-    type Signature = Signature;
-    type RecoveryId = ();
-
     fn public_key_bytes(&self) -> &[u8] {
         self.public_key_point.as_bytes()
     }
@@ -36,7 +33,7 @@ impl AccountKeyPair for P256KeyPair {
         self.secret_key_field_key.as_ref()
     }
 
-    fn sign(&self, message: &[u8]) -> (Self::Signature, Self::RecoveryId) {
+    fn sign(&self, message: &[u8]) -> (Vec<u8>, Option<u8>) {
         let sig = self
             .secret_key
             .sign_digest(Keccak256::new_with_prefix(message));

--- a/monas-account/src/infrastructure/key_pair/p256_key_pair.rs
+++ b/monas-account/src/infrastructure/key_pair/p256_key_pair.rs
@@ -1,10 +1,10 @@
+use crate::domain::account::AccountKeyPair;
+use p256::ecdsa::signature::digest::Digest;
+use p256::ecdsa::signature::DigestSigner;
 use p256::ecdsa::{SigningKey, VerifyingKey};
 use p256::elliptic_curve::rand_core::OsRng;
 use p256::{EncodedPoint, FieldBytes};
-use p256::ecdsa::signature::digest::Digest;
-use p256::ecdsa::signature::DigestSigner;
 use sha3::Keccak256;
-use crate::domain::account::AccountKeyPair;
 
 #[derive(Clone)]
 pub struct P256KeyPair {
@@ -20,7 +20,12 @@ impl P256KeyPair {
         let public_key = VerifyingKey::from(&secret_key);
         let public_key_point = public_key.to_encoded_point(false);
         let secret_key_field_key = secret_key.to_bytes();
-        Self { secret_key, public_key, public_key_point, secret_key_field_key }
+        Self {
+            secret_key,
+            public_key,
+            public_key_point,
+            secret_key_field_key,
+        }
     }
 }
 
@@ -47,14 +52,13 @@ impl PartialEq for P256KeyPair {
     }
 }
 
-
 #[cfg(test)]
 mod p256_key_pair_tests {
-    use k256::ecdsa::{Signature, VerifyingKey};
-    use sha3::{Digest, Keccak256};
-    use p256::ecdsa::{signature::DigestVerifier};
     use crate::domain::account::AccountKeyPair;
     use crate::infrastructure::key_pair::p256_key_pair::P256KeyPair;
+    use k256::ecdsa::{Signature, VerifyingKey};
+    use p256::ecdsa::signature::DigestVerifier;
+    use sha3::{Digest, Keccak256};
 
     #[test]
     fn generate_has_valid_sizes() {
@@ -71,13 +75,14 @@ mod p256_key_pair_tests {
 
         let (sig_bytes, _rec_id) = p256.sign(message);
 
-        let signature = Signature::from_slice(&sig_bytes.as_slice())
-            .expect("invalid signature bytes");
+        let signature =
+            Signature::from_slice(&sig_bytes.as_slice()).expect("invalid signature bytes");
 
         let verifying_key = VerifyingKey::from_sec1_bytes(p256.public_key_bytes())
             .expect("invalid public key bytes");
 
-        verifying_key.verify_digest(Keccak256::new_with_prefix(message), &signature)
+        verifying_key
+            .verify_digest(Keccak256::new_with_prefix(message), &signature)
             .expect("signature should verify");
     }
 

--- a/monas-account/src/infrastructure/key_pair/p256_key_pair.rs
+++ b/monas-account/src/infrastructure/key_pair/p256_key_pair.rs
@@ -9,7 +9,6 @@ use sha3::Keccak256;
 #[derive(Clone)]
 pub struct P256KeyPair {
     secret_key: SigningKey,
-    public_key: VerifyingKey,
     public_key_point: EncodedPoint,
     secret_key_field_key: FieldBytes,
 }
@@ -22,7 +21,6 @@ impl P256KeyPair {
         let secret_key_field_key = secret_key.to_bytes();
         Self {
             secret_key,
-            public_key,
             public_key_point,
             secret_key_field_key,
         }
@@ -76,7 +74,7 @@ mod p256_key_pair_tests {
         let (sig_bytes, _rec_id) = p256.sign(message);
 
         let signature =
-            Signature::from_slice(&sig_bytes.as_slice()).expect("invalid signature bytes");
+            Signature::from_slice(sig_bytes.as_slice()).expect("invalid signature bytes");
 
         let verifying_key = VerifyingKey::from_sec1_bytes(p256.public_key_bytes())
             .expect("invalid public key bytes");

--- a/monas-account/src/presentation/account.rs
+++ b/monas-account/src/presentation/account.rs
@@ -17,10 +17,7 @@ pub struct GeneratedKeyPair {
 }
 
 impl GeneratedKeyPair {
-    pub fn new(
-        public_key: Vec<u8>,
-        secret_key: Vec<u8>,
-    ) -> Self {
+    pub fn new(public_key: Vec<u8>, secret_key: Vec<u8>) -> Self {
         Self {
             public_key,
             secret_key,
@@ -47,11 +44,9 @@ fn to_response(account: Account) -> Response {
     let key_pair = account.keypair();
     let generated_key_pair = GeneratedKeyPair::new(
         Vec::from(key_pair.public_key_bytes()),
-        Vec::from(key_pair.secret_key_bytes())
+        Vec::from(key_pair.secret_key_bytes()),
     );
-    Response {
-        generated_key_pair
-    }
+    Response { generated_key_pair }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Background
The domain layer was directly depending on the infrastructure’s KeyPair implementation, violating the Dependency Inversion Principle and leaking cryptographic details into business logic.

## Solution
We introduced an AccountKeyPair trait in the domain layer and had the infrastructure-specific types (K256KeyPair / P256KeyPair) implement it. The Account entity now accepts a Box<dyn AccountKeyPair> instead of concrete key‑pair types, decoupling it from the infrastructure.

Key Points & Concerns
Abstraction granularity

- Have we made the API cumbersome by compressing everything into byte arrays (Vec<u8> / &[u8])?

- Safety of byte‑array handling

- Object safety and dynamic dispatch

- Is AccountKeyPair object‑safe, and is the dynamic dispatch overhead acceptable?

## Testability

Can we now mock AccountKeyPair in domain tests without pulling in crypto crates?

## Outcome
Achieved a correct dependency flow: Domain → Trait → Infrastructure

Removed cryptography‑specific types (e.g. SigningKey) from the domain, clarifying the interface

Higher layers (presentation / application services) now work only with raw byte arrays + domain DTOs, with no direct crypto dependencies