### PR TITLE
feat: add monas accunt api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1306,10 +1306,18 @@ dependencies = [
 name = "monas-account"
 version = "0.1.0"
 dependencies = [
+ "axum",
+ "base64",
  "k256",
  "p256",
  "rand_core 0.9.3",
+ "serde",
+ "serde_json",
  "sha3",
+ "sled",
+ "tempfile",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/monas-account/Cargo.toml
+++ b/monas-account/Cargo.toml
@@ -10,3 +10,13 @@ k256 = "0.13.4"
 p256 = "0.13.2"
 rand_core = "0.9.0"
 sha3 = "0.10.8"
+thiserror = "2.0.12"
+sled = "0.34"
+axum = "0.8.7"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+base64 = "0.22"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+
+[dev-dependencies]
+tempfile = "3.19.1"

--- a/monas-account/src/application_service/account_service.rs
+++ b/monas-account/src/application_service/account_service.rs
@@ -169,7 +169,7 @@ mod tests {
     fn sign_returns_not_found_if_key_missing() {
         let store = InMemoryAccountKeyStore::default();
         let err = AccountService::sign(&store, b"msg").unwrap_err();
-        matches!(err, SignError::NotFound);
+        assert!(matches!(err, SignError::NotFound));
     }
 
     #[test]
@@ -180,6 +180,6 @@ mod tests {
         AccountService::delete(&store).unwrap();
 
         let err = AccountService::sign(&store, b"after-delete").unwrap_err();
-        matches!(err, SignError::NotFound);
+        assert!(matches!(err, SignError::NotFound));
     }
 }

--- a/monas-account/src/application_service/account_service.rs
+++ b/monas-account/src/application_service/account_service.rs
@@ -1,9 +1,13 @@
 use crate::domain::account::Account;
-use crate::infrastructure::key_pair::{KeyAlgorithm, KeyPairGenerateFactory};
+use crate::infrastructure::key_pair::{KeyAlgorithm, KeyPairError, KeyPairGenerateFactory};
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum AccountServiceError {
+    #[error("persistence error: {0}")]
     PersistenceError(String),
+
+    #[error("key store error: {0}")]
+    KeyStore(#[from] AccountKeyStoreError),
 }
 
 pub struct AccountService;
@@ -23,49 +27,159 @@ impl From<KeyTypeMapper> for KeyAlgorithm {
 }
 
 impl AccountService {
-    pub fn create(key_type: KeyTypeMapper) -> Result<Account, AccountServiceError> {
-        let generated_key_pair = KeyPairGenerateFactory::generate(key_type.into());
-        Ok(Account::init(generated_key_pair))
+    /// 鍵ペアを生成し、アカウントを構築したうえで必ず永続化するユースケース。
+    pub fn create<S: AccountKeyStore>(
+        store: &S,
+        key_type: KeyTypeMapper,
+    ) -> Result<Account, AccountServiceError> {
+        let algorithm: KeyAlgorithm = key_type.into();
+        let generated_key_pair = KeyPairGenerateFactory::generate(algorithm);
+        let account = Account::new(generated_key_pair);
+
+        let stored = StoredAccountKey {
+            algorithm,
+            public_key: account.public_key_bytes().to_vec(),
+            secret_key: account.secret_key_bytes().to_vec(),
+        };
+
+        store.save(&stored)?;
+
+        Ok(account)
+    }
+
+    pub fn delete<S: AccountKeyStore>(store: &S) -> Result<(), AccountServiceError> {
+        store.delete()?;
+        Ok(())
+    }
+
+    pub fn sign<S: AccountKeyStore>(
+        store: &S,
+        msg: &[u8],
+    ) -> Result<(Vec<u8>, Option<u8>), SignError> {
+        let stored = store.load()?.ok_or(SignError::NotFound)?;
+
+        let key_pair = KeyPairGenerateFactory::from_key_bytes(
+            stored.algorithm,
+            &stored.public_key,
+            &stored.secret_key,
+        )?;
+
+        let account = Account::new(key_pair);
+
+        Ok(account.sign(msg))
     }
 }
 
-#[cfg(test)]
-mod account_application_tests {
-    use crate::application_service::account_service::{AccountService, KeyTypeMapper};
+#[derive(Debug, thiserror::Error)]
+pub enum SignError {
+    #[error("stored account key not found")]
+    NotFound,
+    #[error("key-store error: {0}")]
+    KeyStore(#[from] AccountKeyStoreError),
+    #[error("invalid secret key: {0}")]
+    InvalidKey(#[from] KeyPairError),
+}
 
-    #[test]
-    fn create_valid_key_pair_account_k256() {
-        let account = AccountService::create(KeyTypeMapper::K256).unwrap();
-        account.keypair().public_key_bytes();
-        assert_eq!(account.keypair().public_key_bytes().len(), 65);
-        assert_eq!(account.keypair().secret_key_bytes().len(), 32);
-        assert!(!account.is_deleted());
-    }
+#[derive(Clone)]
+pub struct StoredAccountKey {
+    pub algorithm: KeyAlgorithm,
+    pub public_key: Vec<u8>,
+    pub secret_key: Vec<u8>,
+}
 
-    #[test]
-    fn create_valid_key_pair_account_p256() {
-        let account = AccountService::create(KeyTypeMapper::P256).unwrap();
-        account.keypair().public_key_bytes();
-        assert_eq!(account.keypair().public_key_bytes().len(), 65);
-        assert_eq!(account.keypair().secret_key_bytes().len(), 32);
-        assert!(!account.is_deleted());
-    }
+pub trait AccountKeyStore {
+    fn save(&self, key: &StoredAccountKey) -> Result<(), AccountKeyStoreError>;
+
+    fn load(&self) -> Result<Option<StoredAccountKey>, AccountKeyStoreError>;
+
+    fn delete(&self) -> Result<(), AccountKeyStoreError>;
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AccountKeyStoreError {
+    #[error("storage error: {0}")]
+    Storage(String),
+
+    #[error("invalid key data: {0}")]
+    InvalidKeyData(String),
 }
 
 #[cfg(test)]
-mod key_type_mapper_tests {
-    use crate::application_service::account_service::KeyTypeMapper;
-    use crate::infrastructure::key_pair::KeyAlgorithm;
+mod tests {
+    use super::*;
+    use crate::infrastructure::key_store::InMemoryAccountKeyStore;
 
     #[test]
-    fn to_p256_test() {
-        let key_type: KeyAlgorithm = KeyAlgorithm::from(KeyTypeMapper::P256);
-        assert_eq!(key_type, KeyAlgorithm::P256);
+    fn create_k256_stores_valid_account() {
+        let store = InMemoryAccountKeyStore::default();
+        let account = AccountService::create(&store, KeyTypeMapper::K256).unwrap();
+        assert_eq!(account.public_key_bytes().len(), 65);
+        assert_eq!(account.secret_key_bytes().len(), 32);
     }
 
     #[test]
-    fn to_k256_test() {
-        let key_type: KeyAlgorithm = KeyAlgorithm::from(KeyTypeMapper::K256);
-        assert_eq!(key_type, KeyAlgorithm::K256);
+    fn create_p256_stores_valid_account() {
+        let store = InMemoryAccountKeyStore::default();
+        let account = AccountService::create(&store, KeyTypeMapper::P256).unwrap();
+        assert_eq!(account.public_key_bytes().len(), 65);
+        assert_eq!(account.secret_key_bytes().len(), 32);
+    }
+
+    #[test]
+    fn sign_uses_stored_key() {
+        let store = InMemoryAccountKeyStore::default();
+        let account = AccountService::create(&store, KeyTypeMapper::K256).unwrap();
+        let msg = b"sign-test-message";
+
+        let (sig_from_service, _rec_id1) = AccountService::sign(&store, msg).unwrap();
+        let (sig_from_account, _rec_id2) = account.sign(msg);
+
+        assert_eq!(sig_from_service, sig_from_account);
+    }
+
+    #[test]
+    fn sign_uses_stored_key_p256() {
+        let store = InMemoryAccountKeyStore::default();
+        let account = AccountService::create(&store, KeyTypeMapper::P256).unwrap();
+        let msg = b"sign-test-message-p256";
+
+        let (sig_from_service, _rec_id1) = AccountService::sign(&store, msg).unwrap();
+        let (sig_from_account, _rec_id2) = account.sign(msg);
+
+        assert_eq!(sig_from_service, sig_from_account);
+    }
+
+    // memo: 鍵自体は複数の管理可能になるかもしれないため以下のテストケースは削除される可能性がある。
+    #[test]
+    fn sign_uses_latest_created_key() {
+        let store = InMemoryAccountKeyStore::default();
+
+        AccountService::create(&store, KeyTypeMapper::K256).unwrap();
+        let msg = b"override-test-message";
+
+        let account_latest = AccountService::create(&store, KeyTypeMapper::P256).unwrap();
+
+        let (sig_from_service, _rec_id1) = AccountService::sign(&store, msg).unwrap();
+        let (sig_from_latest, _rec_id2) = account_latest.sign(msg);
+
+        assert_eq!(sig_from_service, sig_from_latest);
+    }
+
+    #[test]
+    fn sign_returns_not_found_if_key_missing() {
+        let store = InMemoryAccountKeyStore::default();
+        let err = AccountService::sign(&store, b"msg").unwrap_err();
+        matches!(err, SignError::NotFound);
+    }
+
+    #[test]
+    fn delete_removes_stored_key() {
+        let store = InMemoryAccountKeyStore::default();
+
+        AccountService::create(&store, KeyTypeMapper::K256).unwrap();
+        AccountService::delete(&store).unwrap();
+
+        let err = AccountService::sign(&store, b"after-delete").unwrap_err();
+        matches!(err, SignError::NotFound);
     }
 }

--- a/monas-account/src/domain/account.rs
+++ b/monas-account/src/domain/account.rs
@@ -5,7 +5,6 @@ pub struct Account {
 /// アカウント = 鍵ペアという前提のシンプルなドメインモデル。
 /// 永続化や削除（ストレージから鍵を消す）はインフラ層の責務とし、
 /// ドメインでは「署名できること」と「鍵素材へのアクセス」に集中する。
-
 impl Account {
     /// 既に生成済みの鍵ペアからアカウントを構築する。
     pub fn new(key_pair: Box<dyn AccountKeyPair>) -> Self {

--- a/monas-account/src/domain/account.rs
+++ b/monas-account/src/domain/account.rs
@@ -1,49 +1,30 @@
-use std::fmt::Debug;
-use std::ops::Deref;
-
 pub struct Account {
     key_pair: Box<dyn AccountKeyPair>,
-    deleted: bool,
 }
 
-#[derive(Debug, Eq, PartialEq)]
-pub enum AccountError {
-    AccountAlreadyDeleted,
-}
+/// アカウント = 鍵ペアという前提のシンプルなドメインモデル。
+/// 永続化や削除（ストレージから鍵を消す）はインフラ層の責務とし、
+/// ドメインでは「署名できること」と「鍵素材へのアクセス」に集中する。
 
 impl Account {
-    pub fn init(key_pair: Box<dyn AccountKeyPair>) -> Self {
-        Account {
-            key_pair,
-            deleted: false,
-        }
+    /// 既に生成済みの鍵ペアからアカウントを構築する。
+    pub fn new(key_pair: Box<dyn AccountKeyPair>) -> Self {
+        Account { key_pair }
     }
 
-    pub fn regenerate_keypair(
-        &self,
-        key_pair: Box<dyn AccountKeyPair>,
-    ) -> Result<Account, AccountError> {
-        if self.deleted {
-            return Err(AccountError::AccountAlreadyDeleted);
-        }
-        Ok(Self::init(key_pair))
+    /// メッセージに署名する。
+    pub fn sign(&self, msg: &[u8]) -> (Vec<u8>, Option<u8>) {
+        self.key_pair.sign(msg)
     }
 
-    //ContentNodeに通達する
-    pub fn delete(&mut self) -> Result<(), AccountError> {
-        if self.deleted {
-            return Err(AccountError::AccountAlreadyDeleted);
-        }
-        self.deleted = true;
-        Ok(())
+    /// 公開鍵バイト列へのアクセス。
+    pub fn public_key_bytes(&self) -> &[u8] {
+        self.key_pair.public_key_bytes()
     }
 
-    pub fn keypair(&self) -> &dyn AccountKeyPair {
-        self.key_pair.deref()
-    }
-
-    pub fn is_deleted(&self) -> bool {
-        self.deleted
+    /// 秘密鍵バイト列へのアクセス。
+    pub fn secret_key_bytes(&self) -> &[u8] {
+        self.key_pair.secret_key_bytes()
     }
 }
 
@@ -61,36 +42,16 @@ mod account_tests {
     use crate::infrastructure::key_pair::KeyPairGenerateFactory;
 
     #[test]
-    fn regenerate_key_pair() {
-        let before_account = Account::init(KeyPairGenerateFactory::generate(K256));
+    fn create_account_and_use_key_material() {
+        let account = Account::new(KeyPairGenerateFactory::generate(K256));
 
-        let before_key_pair = before_account.key_pair.public_key_bytes();
+        // 公開鍵・秘密鍵のサイズが想定通りであることを確認
+        assert_eq!(account.public_key_bytes().len(), 65);
+        assert_eq!(account.secret_key_bytes().len(), 32);
 
-        let after_account = before_account
-            .regenerate_keypair(KeyPairGenerateFactory::generate(K256))
-            .unwrap();
-
-        let after_key_pair = after_account.key_pair.public_key_bytes();
-
-        assert_ne!(before_key_pair, after_key_pair);
-
-        assert!(!before_account.is_deleted());
-    }
-
-    #[test]
-    fn throw_error_regenerate_key_pair_when_account_was_deleted() {
-        let mut account = Account::init(KeyPairGenerateFactory::generate(K256));
-
-        account.delete().unwrap();
-        assert!(account.is_deleted());
-        let result = account.regenerate_keypair(KeyPairGenerateFactory::generate(K256));
-        matches!(result, Err(AccountError::AccountAlreadyDeleted));
-    }
-
-    #[test]
-    fn delete_account() {
-        let mut account = Account::init(KeyPairGenerateFactory::generate(K256));
-        account.delete().unwrap();
-        assert!(account.is_deleted());
+        // 署名が正常に生成できることを確認
+        let message = b"test message";
+        let (sig, _rec_id) = account.sign(message);
+        assert!(!sig.is_empty());
     }
 }

--- a/monas-account/src/infrastructure/key_pair.rs
+++ b/monas-account/src/infrastructure/key_pair.rs
@@ -38,12 +38,10 @@ impl KeyPairGenerateFactory {
     ) -> Result<Box<dyn AccountKeyPair>, KeyPairError> {
         match key_type {
             KeyAlgorithm::K256 => Ok(Box::new(K256KeyPair::from_key_bytes(
-                public_key,
-                secret_key,
+                public_key, secret_key,
             )?)),
             KeyAlgorithm::P256 => Ok(Box::new(P256KeyPair::from_key_bytes(
-                public_key,
-                secret_key,
+                public_key, secret_key,
             )?)),
         }
     }

--- a/monas-account/src/infrastructure/key_pair.rs
+++ b/monas-account/src/infrastructure/key_pair.rs
@@ -29,6 +29,30 @@ impl KeyPairGenerateFactory {
             KeyAlgorithm::P256 => Box::new(P256KeyPair::generate()),
         }
     }
+
+    /// 永続化された鍵バイト列から鍵ペアを復元する。
+    pub fn from_key_bytes(
+        key_type: KeyAlgorithm,
+        public_key: &[u8],
+        secret_key: &[u8],
+    ) -> Result<Box<dyn AccountKeyPair>, KeyPairError> {
+        match key_type {
+            KeyAlgorithm::K256 => Ok(Box::new(K256KeyPair::from_key_bytes(
+                public_key,
+                secret_key,
+            )?)),
+            KeyAlgorithm::P256 => Ok(Box::new(P256KeyPair::from_key_bytes(
+                public_key,
+                secret_key,
+            )?)),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum KeyPairError {
+    #[error("invalid secret key: {0}")]
+    InvalidSecretKey(String),
 }
 
 #[cfg(test)]

--- a/monas-account/src/infrastructure/key_pair/k256_key_pair.rs
+++ b/monas-account/src/infrastructure/key_pair/k256_key_pair.rs
@@ -28,7 +28,10 @@ impl K256KeyPair {
     }
 
     /// 永続化された鍵バイト列から K256KeyPair を復元する。
-    pub fn from_key_bytes(public_key: &[u8], secret_key_bytes: &[u8]) -> Result<Self, KeyPairError> {
+    pub fn from_key_bytes(
+        public_key: &[u8],
+        secret_key_bytes: &[u8],
+    ) -> Result<Self, KeyPairError> {
         if public_key.len() != 65 {
             return Err(KeyPairError::InvalidSecretKey(format!(
                 "expected 65 bytes public key, got {}",

--- a/monas-account/src/infrastructure/key_pair/k256_key_pair.rs
+++ b/monas-account/src/infrastructure/key_pair/k256_key_pair.rs
@@ -1,4 +1,5 @@
 use crate::domain::account::AccountKeyPair;
+use crate::infrastructure::key_pair::KeyPairError;
 use k256::ecdsa::signature::DigestSigner;
 use k256::ecdsa::{SigningKey, VerifyingKey};
 use k256::elliptic_curve::rand_core::OsRng;
@@ -24,6 +25,33 @@ impl K256KeyPair {
             public_key_point,
             secret_key_field_key,
         }
+    }
+
+    /// 永続化された鍵バイト列から K256KeyPair を復元する。
+    pub fn from_key_bytes(public_key: &[u8], secret_key_bytes: &[u8]) -> Result<Self, KeyPairError> {
+        if public_key.len() != 65 {
+            return Err(KeyPairError::InvalidSecretKey(format!(
+                "expected 65 bytes public key, got {}",
+                public_key.len()
+            )));
+        }
+        if secret_key_bytes.len() != 32 {
+            return Err(KeyPairError::InvalidSecretKey(format!(
+                "expected 32 bytes, got {}",
+                secret_key_bytes.len()
+            )));
+        }
+        let field = FieldBytes::from_slice(secret_key_bytes);
+        let secret_key = SigningKey::from_bytes(field)
+            .map_err(|e| KeyPairError::InvalidSecretKey(e.to_string()))?;
+        let public_key_point = EncodedPoint::from_bytes(public_key)
+            .map_err(|e| KeyPairError::InvalidSecretKey(e.to_string()))?;
+        let secret_key_field_key = secret_key.to_bytes();
+        Ok(K256KeyPair {
+            secret_key,
+            public_key_point,
+            secret_key_field_key,
+        })
     }
 }
 

--- a/monas-account/src/infrastructure/key_pair/p256_key_pair.rs
+++ b/monas-account/src/infrastructure/key_pair/p256_key_pair.rs
@@ -28,7 +28,10 @@ impl P256KeyPair {
     }
 
     /// 永続化された鍵バイト列から P256KeyPair を復元する。
-    pub fn from_key_bytes(public_key: &[u8], secret_key_bytes: &[u8]) -> Result<Self, KeyPairError> {
+    pub fn from_key_bytes(
+        public_key: &[u8],
+        secret_key_bytes: &[u8],
+    ) -> Result<Self, KeyPairError> {
         if public_key.len() != 65 {
             return Err(KeyPairError::InvalidSecretKey(format!(
                 "expected 65 bytes public key, got {}",
@@ -42,7 +45,7 @@ impl P256KeyPair {
             )));
         }
         let field = FieldBytes::from_slice(secret_key_bytes);
-        let secret_key = SigningKey::from_bytes(&field)
+        let secret_key = SigningKey::from_bytes(field)
             .map_err(|e| KeyPairError::InvalidSecretKey(e.to_string()))?;
         let public_key_point = EncodedPoint::from_bytes(public_key)
             .map_err(|e| KeyPairError::InvalidSecretKey(e.to_string()))?;

--- a/monas-account/src/infrastructure/key_pair/p256_key_pair.rs
+++ b/monas-account/src/infrastructure/key_pair/p256_key_pair.rs
@@ -1,4 +1,5 @@
 use crate::domain::account::AccountKeyPair;
+use crate::infrastructure::key_pair::KeyPairError;
 use p256::ecdsa::signature::digest::Digest;
 use p256::ecdsa::signature::DigestSigner;
 use p256::ecdsa::{SigningKey, VerifyingKey};
@@ -24,6 +25,33 @@ impl P256KeyPair {
             public_key_point,
             secret_key_field_key,
         }
+    }
+
+    /// 永続化された鍵バイト列から P256KeyPair を復元する。
+    pub fn from_key_bytes(public_key: &[u8], secret_key_bytes: &[u8]) -> Result<Self, KeyPairError> {
+        if public_key.len() != 65 {
+            return Err(KeyPairError::InvalidSecretKey(format!(
+                "expected 65 bytes public key, got {}",
+                public_key.len()
+            )));
+        }
+        if secret_key_bytes.len() != 32 {
+            return Err(KeyPairError::InvalidSecretKey(format!(
+                "expected 32 bytes, got {}",
+                secret_key_bytes.len()
+            )));
+        }
+        let field = FieldBytes::from_slice(secret_key_bytes);
+        let secret_key = SigningKey::from_bytes(&field)
+            .map_err(|e| KeyPairError::InvalidSecretKey(e.to_string()))?;
+        let public_key_point = EncodedPoint::from_bytes(public_key)
+            .map_err(|e| KeyPairError::InvalidSecretKey(e.to_string()))?;
+        let secret_key_field_key = secret_key.to_bytes();
+        Ok(Self {
+            secret_key,
+            public_key_point,
+            secret_key_field_key,
+        })
     }
 }
 

--- a/monas-account/src/infrastructure/key_store.rs
+++ b/monas-account/src/infrastructure/key_store.rs
@@ -55,8 +55,7 @@ pub struct SledAccountKeyStore {
 
 impl SledAccountKeyStore {
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, AccountKeyStoreError> {
-        let db =
-            sled::open(path).map_err(|e| AccountKeyStoreError::Storage(e.to_string()))?;
+        let db = sled::open(path).map_err(|e| AccountKeyStoreError::Storage(e.to_string()))?;
         Ok(Self { db })
     }
 
@@ -156,7 +155,7 @@ mod tests {
         let stored = StoredAccountKey {
             algorithm: KeyAlgorithm::K256,
             public_key: vec![0; 65],
-            secret_key: vec![1, 2, 3, 4],
+            secret_key: vec![1; 32],
         };
 
         // save
@@ -181,7 +180,8 @@ mod tests {
         let stored = StoredAccountKey {
             algorithm: KeyAlgorithm::P256,
             public_key: vec![0; 65],
-            secret_key: vec![10, 20, 30, 40],
+            // 実際の鍵サイズ(32バイト)に合わせてテストデータを用意する
+            secret_key: vec![2; 32],
         };
 
         // save
@@ -197,5 +197,3 @@ mod tests {
         assert!(store.load().unwrap().is_none());
     }
 }
-
-

--- a/monas-account/src/infrastructure/key_store.rs
+++ b/monas-account/src/infrastructure/key_store.rs
@@ -1,0 +1,201 @@
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use crate::application_service::account_service::{
+    AccountKeyStore, AccountKeyStoreError, StoredAccountKey,
+};
+
+/// プロセス内の `AccountKeyMaterial` を保存するインメモリ実装。
+///
+/// - 永続化は行わず、プロセス終了とともに破棄される。
+/// - ローカル開発やテスト、PoC 用途を想定。
+#[derive(Clone, Default)]
+pub struct InMemoryAccountKeyStore {
+    inner: Arc<Mutex<Option<StoredAccountKey>>>,
+}
+
+impl AccountKeyStore for InMemoryAccountKeyStore {
+    fn save(&self, key: &StoredAccountKey) -> Result<(), AccountKeyStoreError> {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|e| AccountKeyStoreError::Storage(e.to_string()))?;
+
+        *guard = Some(key.clone());
+        Ok(())
+    }
+
+    fn load(&self) -> Result<Option<StoredAccountKey>, AccountKeyStoreError> {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|e| AccountKeyStoreError::Storage(e.to_string()))?;
+
+        Ok(guard.clone())
+    }
+
+    fn delete(&self) -> Result<(), AccountKeyStoreError> {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|e| AccountKeyStoreError::Storage(e.to_string()))?;
+
+        *guard = None;
+        Ok(())
+    }
+}
+
+/// sled を用いたアカウント鍵ストア実装。
+///
+/// - キー: 固定文字列 `"account:signing_key"`（UTF-8 文字列）
+/// - 値: 1 バイトのアルゴリズム識別子 + 公開鍵バイト列(65バイト) + 秘密鍵バイト列(32バイト)
+pub struct SledAccountKeyStore {
+    db: sled::Db,
+}
+
+impl SledAccountKeyStore {
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, AccountKeyStoreError> {
+        let db =
+            sled::open(path).map_err(|e| AccountKeyStoreError::Storage(e.to_string()))?;
+        Ok(Self { db })
+    }
+
+    fn sled_key() -> &'static str {
+        "account:signing_key"
+    }
+}
+
+impl AccountKeyStore for SledAccountKeyStore {
+    fn save(&self, key: &StoredAccountKey) -> Result<(), AccountKeyStoreError> {
+        use crate::infrastructure::key_pair::KeyAlgorithm;
+
+        let alg_tag = match key.algorithm {
+            KeyAlgorithm::K256 => 1u8,
+            KeyAlgorithm::P256 => 2u8,
+        };
+
+        // 現状どちらのアルゴリズムも secp256 系で、
+        // - public_key: 65 bytes
+        // - secret_key: 32 bytes
+        let mut value = Vec::with_capacity(1 + key.public_key.len() + key.secret_key.len());
+        value.push(alg_tag);
+        value.extend_from_slice(&key.public_key);
+        value.extend_from_slice(&key.secret_key);
+
+        self.db
+            .insert(Self::sled_key(), value)
+            .map_err(|e| AccountKeyStoreError::Storage(e.to_string()))?;
+        self.db
+            .flush()
+            .map_err(|e| AccountKeyStoreError::Storage(e.to_string()))?;
+
+        Ok(())
+    }
+
+    fn load(&self) -> Result<Option<StoredAccountKey>, AccountKeyStoreError> {
+        use crate::infrastructure::key_pair::KeyAlgorithm;
+
+        let opt = self
+            .db
+            .get(Self::sled_key())
+            .map_err(|e| AccountKeyStoreError::Storage(e.to_string()))?;
+
+        let Some(ivec) = opt else {
+            return Ok(None);
+        };
+
+        let bytes = ivec.as_ref();
+        if bytes.len() < 1 + 65 + 32 {
+            return Err(AccountKeyStoreError::InvalidKeyData(
+                "value too short".to_string(),
+            ));
+        }
+
+        let alg_tag = bytes[0];
+        let algorithm = match alg_tag {
+            1 => KeyAlgorithm::K256,
+            2 => KeyAlgorithm::P256,
+            other => {
+                return Err(AccountKeyStoreError::InvalidKeyData(format!(
+                    "unknown algorithm tag: {other}"
+                )))
+            }
+        };
+
+        let public_key = bytes[1..1 + 65].to_vec();
+        let secret_key = bytes[1 + 65..].to_vec();
+
+        Ok(Some(StoredAccountKey {
+            algorithm,
+            public_key,
+            secret_key,
+        }))
+    }
+
+    fn delete(&self) -> Result<(), AccountKeyStoreError> {
+        self.db
+            .remove(Self::sled_key())
+            .map_err(|e| AccountKeyStoreError::Storage(e.to_string()))?;
+        self.db
+            .flush()
+            .map_err(|e| AccountKeyStoreError::Storage(e.to_string()))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::application_service::account_service::StoredAccountKey;
+    use crate::infrastructure::key_pair::KeyAlgorithm;
+
+    #[test]
+    fn in_memory_store_save_load_delete() {
+        let store = InMemoryAccountKeyStore::default();
+
+        let stored = StoredAccountKey {
+            algorithm: KeyAlgorithm::K256,
+            public_key: vec![0; 65],
+            secret_key: vec![1, 2, 3, 4],
+        };
+
+        // save
+        store.save(&stored).unwrap();
+
+        // load
+        let loaded = store.load().unwrap().expect("should exist");
+        assert_eq!(loaded.algorithm, stored.algorithm);
+        assert_eq!(loaded.secret_key, stored.secret_key);
+
+        // delete
+        store.delete().unwrap();
+        assert!(store.load().unwrap().is_none());
+    }
+
+    #[test]
+    fn sled_store_save_load_delete() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("account_db");
+        let store = SledAccountKeyStore::open(&path).expect("open sled");
+
+        let stored = StoredAccountKey {
+            algorithm: KeyAlgorithm::P256,
+            public_key: vec![0; 65],
+            secret_key: vec![10, 20, 30, 40],
+        };
+
+        // save
+        store.save(&stored).unwrap();
+
+        // load
+        let loaded = store.load().unwrap().expect("should exist");
+        assert_eq!(loaded.algorithm, stored.algorithm);
+        assert_eq!(loaded.secret_key, stored.secret_key);
+
+        // delete
+        store.delete().unwrap();
+        assert!(store.load().unwrap().is_none());
+    }
+}
+
+

--- a/monas-account/src/infrastructure/mod.rs
+++ b/monas-account/src/infrastructure/mod.rs
@@ -1,2 +1,3 @@
 pub mod key_pair;
 pub mod public_key_repository;
+pub mod key_store;

--- a/monas-account/src/infrastructure/mod.rs
+++ b/monas-account/src/infrastructure/mod.rs
@@ -1,3 +1,3 @@
 pub mod key_pair;
-pub mod public_key_repository;
 pub mod key_store;
+pub mod public_key_repository;

--- a/monas-account/src/main.rs
+++ b/monas-account/src/main.rs
@@ -21,5 +21,3 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
-
-

--- a/monas-account/src/main.rs
+++ b/monas-account/src/main.rs
@@ -1,0 +1,25 @@
+use std::net::SocketAddr;
+
+use tokio::net::TcpListener;
+
+use monas_account::presentation;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let app = presentation::create_router();
+
+    let port: u16 = std::env::var("MONAS_ACCOUNT_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(4002);
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    println!("monas-account server listening on http://{addr}");
+
+    let listener = TcpListener::bind(addr).await?;
+    axum::serve(listener, app).await?;
+
+    Ok(())
+}
+
+

--- a/monas-account/src/presentation/account.rs
+++ b/monas-account/src/presentation/account.rs
@@ -42,14 +42,16 @@ pub fn routes() -> Router<Arc<AppState>> {
         .route("/accounts/sign", post(sign_account))
 }
 
-fn parse_key_type(s: &str) -> Result<crate::application_service::account_service::KeyTypeMapper, (StatusCode, String)> {
+fn parse_key_type(
+    s: &str,
+) -> Result<crate::application_service::account_service::KeyTypeMapper, (StatusCode, String)> {
     use crate::application_service::account_service::KeyTypeMapper;
     match s.to_uppercase().as_str() {
         "K256" => Ok(KeyTypeMapper::K256),
         "P256" => Ok(KeyTypeMapper::P256),
         other => Err((
             StatusCode::BAD_REQUEST,
-            format!("unsupported key_type: {}", other),
+            format!("unsupported key_type: {other}"),
         )),
     }
 }
@@ -85,9 +87,12 @@ async fn sign_account(
     State(state): State<Arc<AppState>>,
     Json(req): Json<SignRequest>,
 ) -> Result<Json<SignResponse>, (StatusCode, String)> {
-    let msg = BASE64_STANDARD
-        .decode(&req.message_base64)
-        .map_err(|e| (StatusCode::BAD_REQUEST, format!("invalid message_base64: {e}")))?;
+    let msg = BASE64_STANDARD.decode(&req.message_base64).map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("invalid message_base64: {e}"),
+        )
+    })?;
 
     let (sig, _rec_id) = AccountService::sign(&state.key_store, &msg).map_err(|e| {
         let status = match e {
@@ -99,7 +104,5 @@ async fn sign_account(
 
     let signature_base64 = BASE64_STANDARD.encode(&sig);
 
-    Ok(Json(SignResponse {
-        signature_base64
-    }))
+    Ok(Json(SignResponse { signature_base64 }))
 }

--- a/monas-account/src/presentation/account.rs
+++ b/monas-account/src/presentation/account.rs
@@ -1,65 +1,105 @@
-use crate::application_service::account_service::{
-    AccountService, AccountServiceError, KeyTypeMapper,
+use std::sync::Arc;
+
+use axum::{
+    extract::{Json, State},
+    http::StatusCode,
+    routing::post,
+    Router,
 };
-use crate::domain::account::Account;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine;
+use serde::{Deserialize, Serialize};
 
-pub struct ReqArguments {
-    pub generating_key_type: KeyTypeMapper,
+use crate::application_service::account_service::{AccountService, SignError};
+
+use super::AppState;
+
+#[derive(Deserialize)]
+pub struct CreateAccountRequest {
+    pub key_type: String,
 }
 
-pub struct Response {
-    pub generated_key_pair: GeneratedKeyPair,
+#[derive(Serialize)]
+pub struct CreateAccountResponse {
+    pub algorithm: String,
+    pub public_key_base64: String,
+    pub secret_key_base64: String,
 }
 
-pub struct GeneratedKeyPair {
-    pub public_key: Vec<u8>,
-    pub secret_key: Vec<u8>,
+#[derive(Deserialize)]
+pub struct SignRequest {
+    pub message_base64: String,
 }
 
-impl GeneratedKeyPair {
-    pub fn new(public_key: Vec<u8>, secret_key: Vec<u8>) -> Self {
-        Self {
-            public_key,
-            secret_key,
-        }
+#[derive(Serialize)]
+pub struct SignResponse {
+    pub signature_base64: String,
+}
+
+pub fn routes() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/accounts", post(create_account).delete(delete_account))
+        .route("/accounts/sign", post(sign_account))
+}
+
+fn parse_key_type(s: &str) -> Result<crate::application_service::account_service::KeyTypeMapper, (StatusCode, String)> {
+    use crate::application_service::account_service::KeyTypeMapper;
+    match s.to_uppercase().as_str() {
+        "K256" => Ok(KeyTypeMapper::K256),
+        "P256" => Ok(KeyTypeMapper::P256),
+        other => Err((
+            StatusCode::BAD_REQUEST,
+            format!("unsupported key_type: {}", other),
+        )),
     }
-
-    pub fn public_key(&self) -> &[u8] {
-        self.public_key.as_slice()
-    }
-
-    pub fn secret_key(&self) -> &[u8] {
-        self.secret_key.as_slice()
-    }
 }
 
-pub fn create(args: ReqArguments) -> Result<Response, AccountServiceError> {
-    match AccountService::create(args.generating_key_type) {
-        Ok(account) => Ok(to_response(account)),
-        Err(e) => Err(e),
-    }
+async fn create_account(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<CreateAccountRequest>,
+) -> Result<Json<CreateAccountResponse>, (StatusCode, String)> {
+    let key_type = parse_key_type(&req.key_type)?;
+
+    let account = AccountService::create(&state.key_store, key_type)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    let public_key_base64 = BASE64_STANDARD.encode(account.public_key_bytes());
+    let secret_key_base64 = BASE64_STANDARD.encode(account.secret_key_bytes());
+
+    Ok(Json(CreateAccountResponse {
+        algorithm: req.key_type.to_uppercase(),
+        public_key_base64,
+        secret_key_base64,
+    }))
 }
 
-fn to_response(account: Account) -> Response {
-    let key_pair = account.keypair();
-    let generated_key_pair = GeneratedKeyPair::new(
-        Vec::from(key_pair.public_key_bytes()),
-        Vec::from(key_pair.secret_key_bytes()),
-    );
-    Response { generated_key_pair }
+async fn delete_account(
+    State(state): State<Arc<AppState>>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    AccountService::delete(&state.key_store)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+    Ok(StatusCode::NO_CONTENT)
 }
 
-#[cfg(test)]
-mod account_presentation_tests {
-    use super::*;
+async fn sign_account(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<SignRequest>,
+) -> Result<Json<SignResponse>, (StatusCode, String)> {
+    let msg = BASE64_STANDARD
+        .decode(&req.message_base64)
+        .map_err(|e| (StatusCode::BAD_REQUEST, format!("invalid message_base64: {e}")))?;
 
-    #[test]
-    fn account_create_test() {
-        let args = ReqArguments {
-            generating_key_type: KeyTypeMapper::K256,
+    let (sig, _rec_id) = AccountService::sign(&state.key_store, &msg).map_err(|e| {
+        let status = match e {
+            SignError::NotFound => StatusCode::NOT_FOUND,
+            SignError::KeyStore(_) | SignError::InvalidKey(_) => StatusCode::BAD_REQUEST,
         };
-        let result = create(args).unwrap();
-        println!("{:?}", result.generated_key_pair.public_key);
-        assert!(!result.generated_key_pair.public_key.is_empty());
-    }
+        (status, e.to_string())
+    })?;
+
+    let signature_base64 = BASE64_STANDARD.encode(&sig);
+
+    Ok(Json(SignResponse {
+        signature_base64
+    }))
 }

--- a/monas-account/src/presentation/mod.rs
+++ b/monas-account/src/presentation/mod.rs
@@ -1,1 +1,20 @@
+use std::sync::Arc;
+use axum::Router;
+use crate::infrastructure::key_store::InMemoryAccountKeyStore;
+
 pub mod account;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub key_store: InMemoryAccountKeyStore,
+}
+
+pub fn create_router() -> Router {
+    let state = Arc::new(AppState {
+        key_store: InMemoryAccountKeyStore::default(),
+    });
+
+    Router::new()
+        .merge(account::routes())
+        .with_state(state)
+}

--- a/monas-account/src/presentation/mod.rs
+++ b/monas-account/src/presentation/mod.rs
@@ -1,6 +1,6 @@
-use std::sync::Arc;
-use axum::Router;
 use crate::infrastructure::key_store::InMemoryAccountKeyStore;
+use axum::Router;
+use std::sync::Arc;
 
 pub mod account;
 
@@ -14,7 +14,5 @@ pub fn create_router() -> Router {
         key_store: InMemoryAccountKeyStore::default(),
     });
 
-    Router::new()
-        .merge(account::routes())
-        .with_state(state)
+    Router::new().merge(account::routes()).with_state(state)
 }

--- a/monas-content/src/application_service/content_service/service.rs
+++ b/monas-content/src/application_service/content_service/service.rs
@@ -1057,7 +1057,7 @@ mod tests {
                 assert_eq!(expected, expected_cid.as_str());
                 assert_eq!(actual, actual_cid.as_str());
             }
-            other => panic!("unexpected error variant: {:?}", other),
+            other => panic!("unexpected error variant: {other:?}"),
         }
     }
 }


### PR DESCRIPTION
## Description

### 目的

- `monas-account` において、**「鍵ペア = アカウント」**という前提でシンプルなドメインモデルを定義する。
- アカウント鍵の **生成 / 保存 / 署名 / 削除** を一貫したフローとして提供する HTTP API を用意する。

### ドメイン層

- `Account`
  - フィールド: `key_pair: Box<dyn AccountKeyPair>`
  - 責務:
    - `new(key_pair)` で構築
    - `sign(&self, msg: &[u8]) -> (Vec<u8>, Option<u8>)`
    - `public_key_bytes(&self) -> &[u8]`
    - `secret_key_bytes(&self) -> &[u8]`
  - 「削除フラグ」や「鍵ローテーション」は持たない（鍵ペアがそのままアカウントの同一性）。

- `AccountKeyPair` トレイト
  - `sign(&self, msg: &[u8]) -> (Vec<u8>, Option<u8>)`
  - `public_key_bytes(&self) -> &[u8]`
  - `secret_key_bytes(&self) -> &[u8]`

### アプリケーション層 (`AccountService`)

- `KeyTypeMapper`
  - `K256` / `P256` を表現し、`KeyAlgorithm` との変換を担う。

- ユースケース
  - `create<S: AccountKeyStore>(&S, KeyTypeMapper) -> Result<Account, AccountServiceError>`
    - `KeyPairGenerateFactory` で鍵ペア生成。
    - `Account` を構築し、`StoredAccountKey` としてストアに永続化。
  - `sign<S: AccountKeyStore>(&S, msg: &[u8]) -> Result<(Vec<u8>, Option<u8>), SignError>`
    - ストアから `StoredAccountKey` をロードし、鍵ペアを復元して署名。
  - `delete<S: AccountKeyStore>(&S) -> Result<(), AccountServiceError>`
    - ストアから鍵を物理削除。

- 保存フォーマット
  - `StoredAccountKey { algorithm: KeyAlgorithm, public_key: Vec<u8>, secret_key: Vec<u8> }`
  - `AccountKeyStore` トレイトで `save / load / delete` を定義。

### インフラ層

- 鍵ペア実装
  - `K256KeyPair`, `P256KeyPair`
    - `generate()` で新規鍵ペア生成。
    - `from_key_bytes(public_key, secret_key)` で保存済みバイト列から復元（長さチェックあり）。

- キーストア
  - `InMemoryAccountKeyStore`
    - `Arc<Mutex<Option<StoredAccountKey>>>` で 1 つだけ鍵を保持。
  - `SledAccountKeyStore`
    - キー: 固定 `"account:signing_key"`
    - 値: `1byte alg_tag + 65byte public_key + 32byte secret_key`
    - `save / load / delete` 実装済み。

### プレゼンテーション層 (HTTP API)

- `presentation::AppState`
  - フィールド: `key_store: InMemoryAccountKeyStore`
  - `create_router() -> Router` で `account::routes()` をマウント。

- エンドポイント
  - `POST /accounts`
    - Req: `{"key_type": "K256" | "P256"}`
    - Res: `{"algorithm": "...", "public_key_base64": "...", "secret_key_base64": "..."}`  
      → アカウント鍵を生成し、Base64 で返す。
  - `DELETE /accounts`
    - アカウント鍵を削除（`AccountService::delete`）。
    - 成功時は `204 No Content`。
  - `POST /accounts/sign`
    - Req: `{"message_base64": "..."}`（署名対象メッセージの Base64）
    - Res: `{"signature_base64": "..."}`  
      → 保存済み鍵で署名し、署名を Base64 で返す。
    - エラー:
      - 鍵なし: `404 Not Found` (`SignError::NotFound`)
      - それ以外（ストア・鍵フォーマット不整合）: `400 Bad Request`

### エントリポイント

- `monas-account/src/main.rs`
  - `MONAS_ACCOUNT_PORT`（デフォルト `4002`）で HTTP サーバを起動。
  - `tokio::net::TcpListener` + `axum::serve` で `presentation::create_router()` を公開。

### 動作確認
鍵の作成:
```
curl -X POST http://127.0.0.1:4002/accounts \
  -H "Content-Type: application/json" \
  -d '{"key_type":"K256"}'
  ```
res:
```
{"algorithm":"K256","public_key_base64":"BL/+F9VbciZ6P7Ok1IeMEzegbSmnx2aC+j5IaCZUmHnlY3IhKlXOUj8umz7rt0CCQu+ra03FsxHLIncUeNDiLJk=","secret_key_base64":"M5kIB/o2Vva1EMZ91gLGMXYtJe9lYV7NcHWKR7ANJeE="}
```

署名の生成:
```
echo -n 'hello-monas' | base64   // aGVsbG8tbW9uYXM=
curl -X POST http://127.0.0.1:4002/accounts/sign \
  -H "Content-Type: application/json" \
  -d '{"message_base64":"aGVsbG8tbW9uYXM="}'
```
res:
```
{"signature_base64":"meYn/mHckp9pw/KiI/Tic4ZcWNel4C3XVLk6e2IfAKVqk4pIQYNdwMSk933ZN7W1/EPgLVHans5mgMLVWd7pTg=="}
```
鍵の削除:
```
curl -X DELETE http://127.0.0.1:4002/accounts -i
```
res:
```
HTTP/1.1 204 No Content
date: Fri, 28 Nov 2025 15:15:07 GMT
```

## Notes & open questions
- 現状は鍵の保存は1つのみにしている
  - keyがないため。複数の鍵が必要になった際に考えようと思う
- 基本的なAPIのみの実装にしてあるため、必要になったら追加していく予定