### PR TITLE
feat: add ipfs provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,10 +304,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-x"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base256emoji"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e9430d9a245a77c92176e649af6e275f20839a48389859d1661e9a128d077c"
+dependencies = [
+ "const-str",
+ "match-lookup",
+]
 
 [[package]]
 name = "base64"
@@ -435,6 +451,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cid"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3147d8272e8fa0ccd29ce51194dd98f79ddfb8191ba9e3409884e751798acf3a"
+dependencies = [
+ "core2",
+ "multibase",
+ "multihash",
+ "unsigned-varint",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,6 +489,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-str"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +509,15 @@ dependencies = [
  "hax-lib",
  "pastey",
  "rand 0.9.2",
+]
+
+[[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -565,6 +608,32 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
+name = "data-encoding-macro"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47ce6c96ea0102f01122a185683611bd5ac8d99e62bc59dd12e6bda344ee673d"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
+dependencies = [
+ "data-encoding",
  "syn 2.0.106",
 ]
 
@@ -1483,6 +1552,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "match-lookup"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1265724d8cb29dbbc2b0f06fffb8bf1a8c0cf73a78eede9ba73a4a66c52a981e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1594,14 +1674,39 @@ name = "monas-filesync"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "cid",
+ "multihash",
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "time",
  "tokio",
  "toml",
  "urlencoding",
+]
+
+[[package]]
+name = "multibase"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8694bb4835f452b0e3bb06dbebb1d6fc5385b6ca1caf2e55fd165c042390ec77"
+dependencies = [
+ "base-x",
+ "base256emoji",
+ "data-encoding",
+ "data-encoding-macro",
+]
+
+[[package]]
+name = "multihash"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
+dependencies = [
+ "core2",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -2695,6 +2800,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "unsigned-varint"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
 
 [[package]]
 name = "untrusted"

--- a/monas-filesync/Cargo.toml
+++ b/monas-filesync/Cargo.toml
@@ -23,3 +23,6 @@ cloud-connectivity = ["reqwest", "time", "serde_json", "urlencoding"]
 [dev-dependencies]
 tokio = { version = "1.0", features = ["rt", "macros"] }
 tempfile = "3"
+cid = "0.11"
+multihash = "0.19"
+sha2 = "0.10"

--- a/monas-filesync/src/infrastructure/providers/ipfs.rs
+++ b/monas-filesync/src/infrastructure/providers/ipfs.rs
@@ -12,39 +12,239 @@ impl IpfsProvider {
             gateway: gateway.into(),
         }
     }
+
+    #[cfg(not(feature = "cloud-connectivity"))]
+    fn feature_disabled_error(op: &str) -> FetchError {
+        FetchError {
+            message: format!(
+                "IPFS {op} requires the `cloud-connectivity` feature (enables reqwest)"
+            ),
+        }
+    }
+
+    #[cfg(feature = "cloud-connectivity")]
+    fn 
+    extract_cid(path: &str) -> Result<&str, FetchError> {
+        const PREFIX: &str = "ipfs://";
+
+        if !path.starts_with(PREFIX) {
+            return Err(FetchError {
+                message: format!("unsupported IPFS URI: {path}"),
+            });
+        }
+
+        let cid = &path[PREFIX.len()..];
+        if cid.is_empty() {
+            return Err(FetchError {
+                message: "IPFS URI is missing a CID".into(),
+            });
+        }
+
+        // CID must not contain a slash (we only support raw blocks for now).
+        // If you need directory/path support later, use `/ipfs/<cid>/...` style in a new scheme.
+        if cid.contains('/') {
+            return Err(FetchError {
+                message: format!(
+                    "invalid IPFS CID URI: {path} (expected `ipfs://<cid>` without subpaths)"
+                ),
+            });
+        }
+
+        Ok(cid)
+    }
+
+    #[cfg(feature = "cloud-connectivity")]
+    fn api_base(&self) -> Result<String, FetchError> {
+        let base = self.gateway.trim_end_matches('/').to_string();
+        if base.is_empty() {
+            return Err(FetchError {
+                message: "IPFS api endpoint is empty".into(),
+            });
+        }
+        Ok(base)
+    }
+
+    #[cfg(feature = "cloud-connectivity")]
+    fn http_client() -> reqwest::Client {
+        reqwest::Client::new()
+    }
+
+    #[cfg(feature = "cloud-connectivity")]
+    fn apply_auth<'a>(
+        mut req: reqwest::RequestBuilder,
+        auth: &'a AuthSession,
+    ) -> reqwest::RequestBuilder {
+        let token = auth.access_token.trim();
+        if !token.is_empty() {
+            req = req.bearer_auth(token);
+        }
+        req
+    }
+
+    #[cfg(feature = "cloud-connectivity")]
+    async fn send_expect_success(
+        req: reqwest::RequestBuilder,
+        err_prefix: &'static str,
+    ) -> Result<reqwest::Response, FetchError> {
+        let resp = req.send().await.map_err(|err| FetchError {
+            message: format!("{err_prefix}: {err}"),
+        })?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(FetchError {
+                message: format!("{err_prefix} with status {status}: {body}"),
+            });
+        }
+
+        Ok(resp)
+    }
+
+    #[cfg(feature = "cloud-connectivity")]
+    async fn fetch_remote(&self, auth: &AuthSession, path: &str) -> Result<Vec<u8>, FetchError> {
+        let cid = Self::extract_cid(path)?;
+        let base = self.api_base()?;
+        let url = format!("{base}/api/v0/block/get?arg={}", urlencoding::encode(cid));
+
+        let client = Self::http_client();
+        let req = Self::apply_auth(client.post(url), auth);
+        let resp = Self::send_expect_success(req, "IPFS fetch request failed").await?;
+        let bytes = resp.bytes().await.map_err(|err| FetchError {
+            message: format!("IPFS fetch failed to read body: {err}"),
+        })?;
+        Ok(bytes.to_vec())
+    }
+
+    #[cfg(feature = "cloud-connectivity")]
+    async fn size_remote(&self, auth: &AuthSession, path: &str) -> Result<u64, FetchError> {
+        let cid = Self::extract_cid(path)?;
+        let base = self.api_base()?;
+        let url = format!("{base}/api/v0/block/stat?arg={}", urlencoding::encode(cid));
+
+        let client = Self::http_client();
+        let req = Self::apply_auth(client.post(url), auth);
+        let resp = Self::send_expect_success(req, "IPFS stat request failed").await?;
+
+        #[derive(serde::Deserialize)]
+        struct BlockStat {
+            #[serde(rename = "Size")]
+            size: u64,
+        }
+
+        let value: BlockStat = resp.json().await.map_err(|err| FetchError {
+            message: format!("IPFS stat JSON decode failed: {err}"),
+        })?;
+        Ok(value.size)
+    }
+
+    #[cfg(feature = "cloud-connectivity")]
+    async fn save_remote(
+        &self,
+        auth: &AuthSession,
+        path: &str,
+        data: &[u8],
+    ) -> Result<(), FetchError> {
+        let expected_cid = Self::extract_cid(path)?;
+        let base = self.api_base()?;
+
+        // Store as a raw block so that CIDv1 + codec=raw matches Monas `ContentId`.
+        let put_url = format!("{base}/api/v0/block/put?format=raw&mhtype=sha2-256");
+
+        let client = Self::http_client();
+        let form = reqwest::multipart::Form::new().part(
+            "data",
+            reqwest::multipart::Part::bytes(data.to_vec())
+                .mime_str("application/octet-stream")
+                .map_err(|err| FetchError {
+                    message: format!("failed to set IPFS multipart mime type: {err}"),
+                })?,
+        );
+        let req = Self::apply_auth(client.post(put_url).multipart(form), auth);
+        let resp = Self::send_expect_success(req, "IPFS block/put request failed").await?;
+
+        #[derive(serde::Deserialize)]
+        struct BlockPut {
+            #[serde(rename = "Key")]
+            key: String,
+        }
+
+        let value: BlockPut = resp.json().await.map_err(|err| FetchError {
+            message: format!("IPFS block/put JSON decode failed: {err}"),
+        })?;
+        let actual_cid = value.key.as_str();
+
+        if actual_cid != expected_cid {
+            return Err(FetchError {
+                message: format!(
+                    "IPFS CID mismatch: expected {expected_cid}, got {actual_cid}"
+                ),
+            });
+        }
+
+        // Ensure retention (Monas default pin strategy).
+        let pin_url = format!("{base}/api/v0/pin/add?arg={}", urlencoding::encode(actual_cid));
+        let pin_req = Self::apply_auth(client.post(pin_url), auth);
+        let _pin_resp = Self::send_expect_success(pin_req, "IPFS pin/add request failed").await?;
+
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait]
 impl StorageProvider for IpfsProvider {
     async fn fetch(
         &self,
-        _auth: &AuthSession,
-        _path: &str,
+        auth: &AuthSession,
+        path: &str,
     ) -> Result<Vec<u8>, crate::infrastructure::FetchError> {
-        Err(FetchError {
-            message: "IPFS provider not implemented".into(),
-        })
+        #[cfg(feature = "cloud-connectivity")]
+        {
+            return self.fetch_remote(auth, path).await;
+        }
+
+        #[cfg(not(feature = "cloud-connectivity"))]
+        {
+            let _ = (auth, path);
+            Err(Self::feature_disabled_error("fetch"))
+        }
     }
 
     async fn size_and_mtime(
         &self,
-        _auth: &AuthSession,
-        _path: &str,
+        auth: &AuthSession,
+        path: &str,
     ) -> Result<(u64, SystemTime), crate::infrastructure::FetchError> {
-        Err(FetchError {
-            message: "IPFS size_and_mtime not implemented".into(),
-        })
+        #[cfg(feature = "cloud-connectivity")]
+        {
+            let size = self.size_remote(auth, path).await?;
+            // IPFS blocks do not have an intrinsic mtime; caller should manage it as metadata.
+            return Ok((size, SystemTime::UNIX_EPOCH));
+        }
+
+        #[cfg(not(feature = "cloud-connectivity"))]
+        {
+            let _ = (auth, path);
+            Err(Self::feature_disabled_error("size_and_mtime"))
+        }
     }
 
     async fn save(
         &self,
-        _auth: &AuthSession,
-        _path: &str,
-        _data: &[u8],
+        auth: &AuthSession,
+        path: &str,
+        data: &[u8],
     ) -> Result<(), crate::infrastructure::FetchError> {
-        Err(FetchError {
-            message: "IPFS save not implemented".into(),
-        })
+        #[cfg(feature = "cloud-connectivity")]
+        {
+            return self.save_remote(auth, path, data).await;
+        }
+
+        #[cfg(not(feature = "cloud-connectivity"))]
+        {
+            let _ = (auth, path, data);
+            Err(Self::feature_disabled_error("save"))
+        }
     }
 }
 
@@ -73,10 +273,6 @@ mod tests {
 
         let result = provider.fetch(&auth, "ipfs://QmHash").await;
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .message
-            .contains("IPFS provider not implemented"));
     }
 
     #[tokio::test]
@@ -88,24 +284,156 @@ mod tests {
 
         let result = provider.size_and_mtime(&auth, "ipfs://QmHash").await;
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .message
-            .contains("IPFS size_and_mtime not implemented"));
     }
 
     #[tokio::test]
+    #[cfg(not(feature = "cloud-connectivity"))]
     async fn test_ipfs_provider_save() {
         let provider = IpfsProvider::new("https://ipfs.io");
         let auth = AuthSession {
             access_token: "test_token".to_string(),
         };
 
-        let result = provider.save(&auth, "ipfs://QmHash", b"test data").await;
+        let result = provider.save(&auth, "ipfs://bafyTEST", b"test data").await;
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .message
-            .contains("IPFS save not implemented"));
+        assert!(result.unwrap_err().message.contains("cloud-connectivity"));
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "cloud-connectivity")]
+    async fn test_ipfs_provider_save_block_put_and_pin_success() {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+        use std::net::Shutdown;
+        use std::sync::mpsc;
+        use std::thread;
+
+        // Minimal HTTP server to capture two requests without extra dependencies.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let base_url = format!("http://{}", addr);
+
+        let (tx, rx) = mpsc::channel::<Vec<(String, Vec<(String, String)>, Vec<u8>)>>();
+        thread::spawn(move || {
+            fn read_one(stream: &mut std::net::TcpStream) -> (String, Vec<(String, String)>, Vec<u8>) {
+                let mut buf = Vec::new();
+                let mut tmp = [0u8; 1024];
+                loop {
+                    let n = stream.read(&mut tmp).unwrap();
+                    if n == 0 {
+                        break;
+                    }
+                    buf.extend_from_slice(&tmp[..n]);
+                    if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                        break;
+                    }
+                }
+
+                let header_end = buf
+                    .windows(4)
+                    .position(|w| w == b"\r\n\r\n")
+                    .unwrap()
+                    + 4;
+                let header_bytes = &buf[..header_end];
+                let mut body = buf[header_end..].to_vec();
+
+                let header_str = String::from_utf8_lossy(header_bytes);
+                let mut lines = header_str.split("\r\n");
+                let request_line = lines.next().unwrap_or("").to_string();
+
+                let mut headers = Vec::new();
+                let mut content_length: usize = 0;
+                for line in lines {
+                    if line.is_empty() {
+                        break;
+                    }
+                    if let Some((k, v)) = line.split_once(':') {
+                        let key = k.trim().to_string();
+                        let val = v.trim().to_string();
+                        if key.eq_ignore_ascii_case("content-length") {
+                            content_length = val.parse().unwrap_or(0);
+                        }
+                        headers.push((key, val));
+                    }
+                }
+
+                while body.len() < content_length {
+                    let n = stream.read(&mut tmp).unwrap();
+                    if n == 0 {
+                        break;
+                    }
+                    body.extend_from_slice(&tmp[..n]);
+                }
+                (request_line, headers, body)
+            }
+
+            let mut captured = Vec::new();
+
+            // 1st request: block/put
+            let (mut stream1, _) = listener.accept().unwrap();
+            let (req1, headers1, body1) = read_one(&mut stream1);
+            captured.push((req1, headers1, body1));
+            let resp1 =
+                b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 18\r\nConnection: close\r\n\r\n{\"Key\":\"bafyTEST\"}";
+            stream1.write_all(resp1).unwrap();
+            let _ = stream1.shutdown(Shutdown::Both);
+            drop(stream1);
+
+            // 2nd request: pin/add
+            let (mut stream2, _) = listener.accept().unwrap();
+            let (req2, headers2, body2) = read_one(&mut stream2);
+            captured.push((req2, headers2, body2));
+            let resp2 = b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+            stream2.write_all(resp2).unwrap();
+            let _ = stream2.shutdown(Shutdown::Both);
+
+            tx.send(captured).unwrap();
+        });
+
+        let provider = IpfsProvider::new(base_url);
+        let auth = AuthSession {
+            access_token: "test_token".to_string(),
+        };
+
+        provider
+            .save(&auth, "ipfs://bafyTEST", b"test data")
+            .await
+            .unwrap();
+
+        let captured = rx.recv().unwrap();
+        assert_eq!(captured.len(), 2);
+
+        let (req1, headers1, body1) = &captured[0];
+        assert!(
+            req1.starts_with("POST /api/v0/block/put?format=raw&mhtype=sha2-256 HTTP/1.1"),
+            "unexpected request line: {req1}"
+        );
+        let mut has_multipart = false;
+        let mut has_auth = false;
+        for (k, v) in headers1 {
+            if k.eq_ignore_ascii_case("content-type") && v.contains("multipart/form-data") {
+                has_multipart = true;
+            }
+            if k.eq_ignore_ascii_case("authorization") && v == "Bearer test_token" {
+                has_auth = true;
+            }
+        }
+        assert!(has_multipart, "missing multipart Content-Type header");
+        assert!(has_auth, "missing Authorization header");
+        assert!(
+            body1.windows(b"test data".len()).any(|w| w == b"test data"),
+            "multipart body did not contain payload"
+        );
+        let body_str = String::from_utf8_lossy(body1);
+        assert!(
+            body_str.contains("Content-Disposition: form-data; name=\"data\""),
+            "missing multipart field name=data"
+        );
+
+        let (req2, _headers2, _body2) = &captured[1];
+        assert!(
+            req2.starts_with("POST /api/v0/pin/add?arg=bafyTEST HTTP/1.1"),
+            "unexpected pin request line: {req2}"
+        );
     }
 }

--- a/monas-filesync/src/infrastructure/providers/ipfs.rs
+++ b/monas-filesync/src/infrastructure/providers/ipfs.rs
@@ -1,6 +1,6 @@
 use std::time::SystemTime;
 
-use crate::infrastructure::{AuthSession, FetchError, StorageProvider};
+use crate::infrastructure::{AuthSession, FetchError, FetchResult, StorageProvider};
 
 pub struct IpfsProvider {
     pub gateway: String,
@@ -23,8 +23,7 @@ impl IpfsProvider {
     }
 
     #[cfg(feature = "cloud-connectivity")]
-    fn 
-    extract_cid(path: &str) -> Result<&str, FetchError> {
+    fn extract_cid(path: &str) -> Result<&str, FetchError> {
         const PREFIX: &str = "ipfs://";
 
         if !path.starts_with(PREFIX) {
@@ -153,7 +152,7 @@ impl IpfsProvider {
 
         let client = Self::http_client();
         let form = reqwest::multipart::Form::new().part(
-            "data",
+            "file",
             reqwest::multipart::Part::bytes(data.to_vec())
                 .mime_str("application/octet-stream")
                 .map_err(|err| FetchError {
@@ -176,14 +175,15 @@ impl IpfsProvider {
 
         if actual_cid != expected_cid {
             return Err(FetchError {
-                message: format!(
-                    "IPFS CID mismatch: expected {expected_cid}, got {actual_cid}"
-                ),
+                message: format!("IPFS CID mismatch: expected {expected_cid}, got {actual_cid}"),
             });
         }
 
         // Ensure retention (Monas default pin strategy).
-        let pin_url = format!("{base}/api/v0/pin/add?arg={}", urlencoding::encode(actual_cid));
+        let pin_url = format!(
+            "{base}/api/v0/pin/add?arg={}",
+            urlencoding::encode(actual_cid)
+        );
         let pin_req = Self::apply_auth(client.post(pin_url), auth);
         let _pin_resp = Self::send_expect_success(pin_req, "IPFS pin/add request failed").await?;
 
@@ -193,11 +193,7 @@ impl IpfsProvider {
 
 #[async_trait::async_trait]
 impl StorageProvider for IpfsProvider {
-    async fn fetch(
-        &self,
-        auth: &AuthSession,
-        path: &str,
-    ) -> Result<Vec<u8>, crate::infrastructure::FetchError> {
+    async fn fetch(&self, auth: &AuthSession, path: &str) -> FetchResult<Vec<u8>> {
         #[cfg(feature = "cloud-connectivity")]
         {
             return self.fetch_remote(auth, path).await;
@@ -214,7 +210,7 @@ impl StorageProvider for IpfsProvider {
         &self,
         auth: &AuthSession,
         path: &str,
-    ) -> Result<(u64, SystemTime), crate::infrastructure::FetchError> {
+    ) -> FetchResult<(u64, SystemTime)> {
         #[cfg(feature = "cloud-connectivity")]
         {
             let size = self.size_remote(auth, path).await?;
@@ -229,12 +225,7 @@ impl StorageProvider for IpfsProvider {
         }
     }
 
-    async fn save(
-        &self,
-        auth: &AuthSession,
-        path: &str,
-        data: &[u8],
-    ) -> Result<(), crate::infrastructure::FetchError> {
+    async fn save(&self, auth: &AuthSession, path: &str, data: &[u8]) -> FetchResult<()> {
         #[cfg(feature = "cloud-connectivity")]
         {
             return self.save_remote(auth, path, data).await;
@@ -251,189 +242,288 @@ impl StorageProvider for IpfsProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::infrastructure::AuthSession;
 
     #[test]
-    fn test_ipfs_provider_new() {
-        let provider = IpfsProvider::new("https://ipfs.io");
-        assert_eq!(provider.gateway, "https://ipfs.io");
+    fn new_stores_gateway() {
+        let gw1 = "https://ipfs.io";
+        let gw2 = String::from("https://gateway.ipfs.io");
 
-        // Test with String type
-        let gateway = String::from("https://gateway.ipfs.io");
-        let provider = IpfsProvider::new(gateway.clone());
-        assert_eq!(provider.gateway, gateway);
+        let p1 = IpfsProvider::new(gw1);
+        let p2 = IpfsProvider::new(gw2.clone());
+
+        assert_eq!(p1.gateway, gw1);
+        assert_eq!(p2.gateway, gw2);
     }
 
-    #[tokio::test]
-    async fn test_ipfs_provider_fetch() {
-        let provider = IpfsProvider::new("https://ipfs.io");
-        let auth = AuthSession {
-            access_token: "test_token".to_string(),
-        };
-
-        let result = provider.fetch(&auth, "ipfs://QmHash").await;
-        assert!(result.is_err());
+    fn auth(token: &str) -> AuthSession {
+        AuthSession {
+            access_token: token.to_string(),
+        }
     }
 
-    #[tokio::test]
-    async fn test_ipfs_provider_size_and_mtime() {
-        let provider = IpfsProvider::new("https://ipfs.io");
-        let auth = AuthSession {
-            access_token: "test_token".to_string(),
-        };
-
-        let result = provider.size_and_mtime(&auth, "ipfs://QmHash").await;
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
     #[cfg(not(feature = "cloud-connectivity"))]
-    async fn test_ipfs_provider_save() {
-        let provider = IpfsProvider::new("https://ipfs.io");
-        let auth = AuthSession {
-            access_token: "test_token".to_string(),
-        };
+    mod without_cloud_connectivity {
+        use super::*;
 
-        let result = provider.save(&auth, "ipfs://bafyTEST", b"test data").await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().message.contains("cloud-connectivity"));
+        #[tokio::test]
+        async fn fetch_returns_feature_disabled_error() {
+            let provider = IpfsProvider::new("https://ipfs.io");
+            let auth = auth("test_token");
+
+            let err = provider.fetch(&auth, "ipfs://bafyTEST").await.unwrap_err();
+
+            assert!(err.message.contains("cloud-connectivity"));
+            assert!(err.message.contains("IPFS fetch"));
+        }
+
+        #[tokio::test]
+        async fn size_and_mtime_returns_feature_disabled_error() {
+            let provider = IpfsProvider::new("https://ipfs.io");
+            let auth = auth("test_token");
+
+            let err = provider
+                .size_and_mtime(&auth, "ipfs://bafyTEST")
+                .await
+                .unwrap_err();
+
+            assert!(err.message.contains("cloud-connectivity"));
+            assert!(err.message.contains("IPFS size_and_mtime"));
+        }
+
+        #[tokio::test]
+        async fn save_returns_feature_disabled_error() {
+            let provider = IpfsProvider::new("https://ipfs.io");
+            let auth = auth("test_token");
+
+            let err = provider
+                .save(&auth, "ipfs://bafyTEST", b"test data")
+                .await
+                .unwrap_err();
+
+            assert!(err.message.contains("cloud-connectivity"));
+            assert!(err.message.contains("IPFS save"));
+        }
     }
 
-    #[tokio::test]
     #[cfg(feature = "cloud-connectivity")]
-    async fn test_ipfs_provider_save_block_put_and_pin_success() {
+    mod with_cloud_connectivity {
+        use super::*;
         use std::io::{Read, Write};
-        use std::net::TcpListener;
-        use std::net::Shutdown;
+        use std::net::{Shutdown, TcpListener};
         use std::sync::mpsc;
         use std::thread;
 
-        // Minimal HTTP server to capture two requests without extra dependencies.
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let addr = listener.local_addr().unwrap();
-        let base_url = format!("http://{}", addr);
-
-        let (tx, rx) = mpsc::channel::<Vec<(String, Vec<(String, String)>, Vec<u8>)>>();
-        thread::spawn(move || {
-            fn read_one(stream: &mut std::net::TcpStream) -> (String, Vec<(String, String)>, Vec<u8>) {
-                let mut buf = Vec::new();
-                let mut tmp = [0u8; 1024];
-                loop {
-                    let n = stream.read(&mut tmp).unwrap();
-                    if n == 0 {
-                        break;
-                    }
-                    buf.extend_from_slice(&tmp[..n]);
-                    if buf.windows(4).any(|w| w == b"\r\n\r\n") {
-                        break;
-                    }
-                }
-
-                let header_end = buf
-                    .windows(4)
-                    .position(|w| w == b"\r\n\r\n")
-                    .unwrap()
-                    + 4;
-                let header_bytes = &buf[..header_end];
-                let mut body = buf[header_end..].to_vec();
-
-                let header_str = String::from_utf8_lossy(header_bytes);
-                let mut lines = header_str.split("\r\n");
-                let request_line = lines.next().unwrap_or("").to_string();
-
-                let mut headers = Vec::new();
-                let mut content_length: usize = 0;
-                for line in lines {
-                    if line.is_empty() {
-                        break;
-                    }
-                    if let Some((k, v)) = line.split_once(':') {
-                        let key = k.trim().to_string();
-                        let val = v.trim().to_string();
-                        if key.eq_ignore_ascii_case("content-length") {
-                            content_length = val.parse().unwrap_or(0);
-                        }
-                        headers.push((key, val));
-                    }
-                }
-
-                while body.len() < content_length {
-                    let n = stream.read(&mut tmp).unwrap();
-                    if n == 0 {
-                        break;
-                    }
-                    body.extend_from_slice(&tmp[..n]);
-                }
-                (request_line, headers, body)
-            }
-
-            let mut captured = Vec::new();
-
-            // 1st request: block/put
-            let (mut stream1, _) = listener.accept().unwrap();
-            let (req1, headers1, body1) = read_one(&mut stream1);
-            captured.push((req1, headers1, body1));
-            let resp1 =
-                b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 18\r\nConnection: close\r\n\r\n{\"Key\":\"bafyTEST\"}";
-            stream1.write_all(resp1).unwrap();
-            let _ = stream1.shutdown(Shutdown::Both);
-            drop(stream1);
-
-            // 2nd request: pin/add
-            let (mut stream2, _) = listener.accept().unwrap();
-            let (req2, headers2, body2) = read_one(&mut stream2);
-            captured.push((req2, headers2, body2));
-            let resp2 = b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
-            stream2.write_all(resp2).unwrap();
-            let _ = stream2.shutdown(Shutdown::Both);
-
-            tx.send(captured).unwrap();
-        });
-
-        let provider = IpfsProvider::new(base_url);
-        let auth = AuthSession {
-            access_token: "test_token".to_string(),
-        };
-
-        provider
-            .save(&auth, "ipfs://bafyTEST", b"test data")
-            .await
-            .unwrap();
-
-        let captured = rx.recv().unwrap();
-        assert_eq!(captured.len(), 2);
-
-        let (req1, headers1, body1) = &captured[0];
-        assert!(
-            req1.starts_with("POST /api/v0/block/put?format=raw&mhtype=sha2-256 HTTP/1.1"),
-            "unexpected request line: {req1}"
-        );
-        let mut has_multipart = false;
-        let mut has_auth = false;
-        for (k, v) in headers1 {
-            if k.eq_ignore_ascii_case("content-type") && v.contains("multipart/form-data") {
-                has_multipart = true;
-            }
-            if k.eq_ignore_ascii_case("authorization") && v == "Bearer test_token" {
-                has_auth = true;
-            }
+        #[derive(Debug)]
+        struct CapturedRequest {
+            request_line: String,
+            headers: Vec<(String, String)>,
+            body: Vec<u8>,
         }
-        assert!(has_multipart, "missing multipart Content-Type header");
-        assert!(has_auth, "missing Authorization header");
-        assert!(
-            body1.windows(b"test data".len()).any(|w| w == b"test data"),
-            "multipart body did not contain payload"
-        );
-        let body_str = String::from_utf8_lossy(body1);
-        assert!(
-            body_str.contains("Content-Disposition: form-data; name=\"data\""),
-            "missing multipart field name=data"
-        );
 
-        let (req2, _headers2, _body2) = &captured[1];
-        assert!(
-            req2.starts_with("POST /api/v0/pin/add?arg=bafyTEST HTTP/1.1"),
-            "unexpected pin request line: {req2}"
-        );
+        fn http_response(status_line: &str, headers: &[(&str, String)], body: &[u8]) -> Vec<u8> {
+            let mut out = Vec::new();
+            out.extend_from_slice(status_line.as_bytes());
+            out.extend_from_slice(b"\r\n");
+            out.extend_from_slice(format!("Content-Length: {}\r\n", body.len()).as_bytes());
+            for (k, v) in headers {
+                out.extend_from_slice(format!("{k}: {v}\r\n").as_bytes());
+            }
+            out.extend_from_slice(b"Connection: close\r\n\r\n");
+            out.extend_from_slice(body);
+            out
+        }
+
+        fn http_json_response(body_json: &str) -> Vec<u8> {
+            http_response(
+                "HTTP/1.1 200 OK",
+                &[("Content-Type", "application/json".to_string())],
+                body_json.as_bytes(),
+            )
+        }
+
+        fn header_value<'a>(headers: &'a [(String, String)], name: &str) -> Option<&'a str> {
+            headers
+                .iter()
+                .find(|(k, _)| k.eq_ignore_ascii_case(name))
+                .map(|(_, v)| v.as_str())
+        }
+
+        fn start_server_with_responses(
+            responses: Vec<Vec<u8>>,
+        ) -> (String, mpsc::Receiver<Vec<CapturedRequest>>) {
+            // Minimal HTTP server to capture N requests without extra dependencies.
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = listener.local_addr().unwrap();
+            let base_url = format!("http://{}", addr);
+
+            let (tx, rx) = mpsc::channel::<Vec<CapturedRequest>>();
+            thread::spawn(move || {
+                fn read_one(stream: &mut std::net::TcpStream) -> CapturedRequest {
+                    let mut buf = Vec::new();
+                    let mut tmp = [0u8; 1024];
+                    loop {
+                        let n = stream.read(&mut tmp).unwrap();
+                        if n == 0 {
+                            break;
+                        }
+                        buf.extend_from_slice(&tmp[..n]);
+                        if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+
+                    let header_end = buf.windows(4).position(|w| w == b"\r\n\r\n").unwrap() + 4;
+                    let header_bytes = &buf[..header_end];
+                    let mut body = buf[header_end..].to_vec();
+
+                    let header_str = String::from_utf8_lossy(header_bytes);
+                    let mut lines = header_str.split("\r\n");
+                    let request_line = lines.next().unwrap_or("").to_string();
+
+                    let mut headers = Vec::new();
+                    let mut content_length: usize = 0;
+                    for line in lines {
+                        if line.is_empty() {
+                            break;
+                        }
+                        if let Some((k, v)) = line.split_once(':') {
+                            let key = k.trim().to_string();
+                            let val = v.trim().to_string();
+                            if key.eq_ignore_ascii_case("content-length") {
+                                content_length = val.parse().unwrap_or(0);
+                            }
+                            headers.push((key, val));
+                        }
+                    }
+
+                    while body.len() < content_length {
+                        let n = stream.read(&mut tmp).unwrap();
+                        if n == 0 {
+                            break;
+                        }
+                        body.extend_from_slice(&tmp[..n]);
+                    }
+
+                    CapturedRequest {
+                        request_line,
+                        headers,
+                        body,
+                    }
+                }
+
+                let mut captured = Vec::new();
+                for response in responses {
+                    let (mut stream, _) = listener.accept().unwrap();
+                    let req = read_one(&mut stream);
+                    captured.push(req);
+                    stream.write_all(&response).unwrap();
+                    let _ = stream.shutdown(Shutdown::Both);
+                }
+                tx.send(captured).unwrap();
+            });
+
+            (base_url, rx)
+        }
+
+        #[tokio::test]
+        async fn fetch_sends_block_get_with_auth_and_returns_bytes() {
+            let expected = b"hello-ipfs".to_vec();
+            let resp = http_response("HTTP/1.1 200 OK", &[], &expected);
+            let (base_url, rx) = start_server_with_responses(vec![resp]);
+            let provider = IpfsProvider::new(base_url);
+            let auth = auth("test_token");
+
+            let actual = provider.fetch(&auth, "ipfs://bafyTEST").await.unwrap();
+
+            assert_eq!(actual, expected);
+            let captured = rx.recv().unwrap();
+            assert_eq!(captured.len(), 1);
+            let req = &captured[0];
+            assert!(
+                req.request_line
+                    .starts_with("POST /api/v0/block/get?arg=bafyTEST HTTP/1.1"),
+                "unexpected request line: {}",
+                req.request_line
+            );
+            assert_eq!(
+                header_value(&req.headers, "authorization"),
+                Some("Bearer test_token")
+            );
+        }
+
+        #[tokio::test]
+        async fn size_and_mtime_sends_block_stat_and_returns_size_and_epoch() {
+            let resp = http_json_response("{\"Size\":123}");
+            let (base_url, rx) = start_server_with_responses(vec![resp]);
+            let provider = IpfsProvider::new(base_url);
+            let auth = auth("test_token");
+
+            let (size, mtime) = provider
+                .size_and_mtime(&auth, "ipfs://bafyTEST")
+                .await
+                .unwrap();
+
+            assert_eq!(size, 123);
+            assert_eq!(mtime, SystemTime::UNIX_EPOCH);
+            let captured = rx.recv().unwrap();
+            assert_eq!(captured.len(), 1);
+            let req = &captured[0];
+            assert!(
+                req.request_line
+                    .starts_with("POST /api/v0/block/stat?arg=bafyTEST HTTP/1.1"),
+                "unexpected request line: {}",
+                req.request_line
+            );
+            assert_eq!(
+                header_value(&req.headers, "authorization"),
+                Some("Bearer test_token")
+            );
+        }
+
+        #[tokio::test]
+        async fn save_sends_block_put_then_pin_add_with_auth_and_payload() {
+            let resp_put = http_json_response("{\"Key\":\"bafyTEST\"}");
+            let resp_pin = http_response("HTTP/1.1 200 OK", &[], &[]);
+            let (base_url, rx) = start_server_with_responses(vec![resp_put, resp_pin]);
+
+            let provider = IpfsProvider::new(base_url);
+            let auth = auth("test_token");
+            let path = "ipfs://bafyTEST";
+            let data = b"test data";
+
+            provider.save(&auth, path, data).await.unwrap();
+
+            let captured = rx.recv().unwrap();
+            assert_eq!(captured.len(), 2);
+
+            let req1 = &captured[0];
+            assert!(
+                req1.request_line
+                    .starts_with("POST /api/v0/block/put?format=raw&mhtype=sha2-256 HTTP/1.1"),
+                "unexpected request line: {}",
+                req1.request_line
+            );
+            let content_type = header_value(&req1.headers, "content-type").unwrap_or("");
+            assert!(content_type.contains("multipart/form-data"));
+            assert_eq!(
+                header_value(&req1.headers, "authorization"),
+                Some("Bearer test_token")
+            );
+            assert!(req1.body.windows(data.len()).any(|w| w == data));
+            let body_str = String::from_utf8_lossy(&req1.body);
+            assert!(body_str.contains("Content-Disposition: form-data; name=\"file\""));
+
+            let req2 = &captured[1];
+            assert!(
+                req2.request_line
+                    .starts_with("POST /api/v0/pin/add?arg=bafyTEST HTTP/1.1"),
+                "unexpected pin request line: {}",
+                req2.request_line
+            );
+            assert_eq!(
+                header_value(&req2.headers, "authorization"),
+                Some("Bearer test_token")
+            );
+        }
     }
 }

--- a/monas-filesync/src/infrastructure/providers/ipfs.rs
+++ b/monas-filesync/src/infrastructure/providers/ipfs.rs
@@ -69,10 +69,7 @@ impl IpfsProvider {
     }
 
     #[cfg(feature = "cloud-connectivity")]
-    fn apply_auth(
-        mut req: reqwest::RequestBuilder,
-        auth: &AuthSession,
-    ) -> reqwest::RequestBuilder {
+    fn apply_auth(mut req: reqwest::RequestBuilder, auth: &AuthSession) -> reqwest::RequestBuilder {
         let token = auth.access_token.trim();
         if !token.is_empty() {
             req = req.bearer_auth(token);

--- a/monas-filesync/src/infrastructure/providers/ipfs.rs
+++ b/monas-filesync/src/infrastructure/providers/ipfs.rs
@@ -69,9 +69,9 @@ impl IpfsProvider {
     }
 
     #[cfg(feature = "cloud-connectivity")]
-    fn apply_auth<'a>(
+    fn apply_auth(
         mut req: reqwest::RequestBuilder,
-        auth: &'a AuthSession,
+        auth: &AuthSession,
     ) -> reqwest::RequestBuilder {
         let token = auth.access_token.trim();
         if !token.is_empty() {
@@ -354,7 +354,7 @@ mod tests {
             // Minimal HTTP server to capture N requests without extra dependencies.
             let listener = TcpListener::bind("127.0.0.1:0").unwrap();
             let addr = listener.local_addr().unwrap();
-            let base_url = format!("http://{}", addr);
+            let base_url = format!("http://{addr}");
 
             let (tx, rx) = mpsc::channel::<Vec<CapturedRequest>>();
             thread::spawn(move || {

--- a/monas-filesync/tests/ipfs_local_daemon.rs
+++ b/monas-filesync/tests/ipfs_local_daemon.rs
@@ -1,0 +1,40 @@
+#![cfg(feature = "cloud-connectivity")]
+
+use std::{env, time::SystemTime};
+
+use cid::Cid;
+use monas_filesync::infrastructure::providers::ipfs::IpfsProvider;
+use monas_filesync::{AuthSession, StorageProvider};
+use multihash::Multihash;
+use sha2::{Digest, Sha256};
+
+fn raw_block_cid_v1_sha2_256(data: &[u8]) -> String {
+    // IPFS `block put --format=raw --mhtype=sha2-256` と同じCIDを生成する。
+    // multicodec: raw (0x55)
+    // multihash code: sha2-256 (0x12)
+    let digest = Sha256::digest(data);
+    let mh = Multihash::<64>::wrap(0x12, digest.as_slice()).expect("digest size must fit");
+    Cid::new_v1(0x55, mh).to_string()
+}
+
+#[tokio::test]
+#[ignore]
+async fn ipfs_local_daemon_roundtrip() {
+    let api_base = env::var("IPFS_API_BASE").unwrap_or_else(|_| "http://127.0.0.1:5001".into());
+    let provider = IpfsProvider::new(api_base);
+    let auth = AuthSession {
+        access_token: env::var("IPFS_API_TOKEN").unwrap_or_default(),
+    };
+
+    let data = b"monas-filesync ipfs roundtrip test";
+    let cid = raw_block_cid_v1_sha2_256(data);
+    let uri = format!("ipfs://{cid}");
+
+    provider.save(&auth, &uri, data).await.unwrap();
+    let fetched = provider.fetch(&auth, &uri).await.unwrap();
+    let (size, mtime) = provider.size_and_mtime(&auth, &uri).await.unwrap();
+
+    assert_eq!(fetched, data);
+    assert_eq!(size, data.len() as u64);
+    assert_eq!(mtime, SystemTime::UNIX_EPOCH);
+}


### PR DESCRIPTION
## Description

`monas-filesync` に **IPFS ストレージプロバイダ**を追加した。`ipfs://<cid>` 形式のURIを扱い、IPFS HTTP API（`/api/v0/*`）経由でブロックの保存・取得・サイズ取得。

- **IPFS Provider追加**（`monas-filesync/src/infrastructure/providers/ipfs.rs`）
  - `StorageProvider` を実装
    - `fetch`: `POST /api/v0/block/get?arg=<cid>`
    - `save`: `POST /api/v0/block/put`（multipart）→ CID一致チェック → `POST /api/v0/pin/add`
    - `size_and_mtime`: `POST /api/v0/block/stat`（mtime はIPFSに無いので `UNIX_EPOCH` を返す）
  - `ipfs://<cid>` のみサポート（サブパス `ipfs://<cid>/...` は非対応）
  - `AuthSession.access_token` があれば Bearer として付与
  - `cloud-connectivity` feature 無効時は明示的にエラーを返す

- **設定/登録**
  - `FilesyncConfig` に `[ipfs] gateway` を追加し、`FetcherRegistry` に `scheme = "ipfs"` で登録
  - 環境変数 `MONAS_IPFS_GATEWAY` で上書き可能

- **依存関係**
  - `cloud-connectivity` featureで `reqwest/time/serde_json/urlencoding` を有効化

- **テスト**
  - `ipfs.rs` 内にユニットテスト追加（feature有無の挙動、HTTPリクエスト組み立て/認証ヘッダ等を最小HTTPサーバで検証）
  - `monas-filesync/tests/ipfs_local_daemon.rs` を追加

### How to test

- ユニットテスト（HTTPモック含む）
  - `cargo test -p monas-filesync --features cloud-connectivity`
- ローカルIPFSデーモン統合テスト（要: `ipfs daemon` / ignore解除で実行）
  - `IPFS_API_BASE=http://127.0.0.1:5001 IPFS_API_TOKEN=... cargo test -p monas-filesync --features cloud-connectivity ipfs_local_daemon_roundtrip -- --ignored --nocapture`

## Notes & open questions
- monas-content側との疎通は未実装
- 実際のipfsのnodeを立てるのか、他のにするのかを決める必要がある