### PR TITLE
fix(state-node): route writes by genesis presence, not membership (invalidate/update HTTP 500)

### DIFF
--- a/monas-state-node/src/application_service/state_node_service.rs
+++ b/monas-state-node/src/application_service/state_node_service.rs
@@ -342,6 +342,23 @@ where
         self.peer_network.listen_addrs().await
     }
 
+    /// Decide whether a write (update/delete/invalidate) should be committed
+    /// locally or relayed to another node.
+    ///
+    /// The deciding factor is whether **this node holds the CRDT genesis** for
+    /// the content, not whether it appears in the ContentNetwork member set.
+    /// Local commits go through `commit_operation`, which fails with "Genesis
+    /// not found" when the genesis is absent. Two cases legitimately lack the
+    /// genesis and must relay instead: the node that first received
+    /// `create_content` (a non-member relay that intentionally never persisted
+    /// the genesis), and a freshly added member that has not yet synced the
+    /// genesis. Both are transient/structural states keyed purely on local CRDT
+    /// presence — no notion of "who created the content" is stored or
+    /// consulted, so membership and creator identity stay private.
+    async fn can_commit_locally(&self, genesis_cid: &str) -> bool {
+        self.crdt_repo.exists(genesis_cid).await.unwrap_or(false)
+    }
+
     /// Classify a relay error message into the appropriate StateNodeError.
     ///
     /// When a member node returns an error during relay, the error message is
@@ -669,9 +686,10 @@ where
             .map_err(|e| StateNodeError::StorageError(e.to_string()))?
             .ok_or_else(|| StateNodeError::ContentNotFound(content_id_vo.clone()))?;
 
-        // 2. Check if local node is a member
-        if network.has_member_str(&self.local_node_id) {
-            // Local delete path: we are a member node
+        // 2. Decide local commit vs relay by genesis presence (not membership):
+        //    only a node that actually holds the CRDT genesis can delete locally.
+        if self.can_commit_locally(content_id).await {
+            // Local delete path: we hold the genesis
             // Authenticate and authorize locally (we have the up-to-date access policy)
             let auth_service = self.auth_service.as_ref().ok_or_else(|| {
                 StateNodeError::InvalidConfiguration("Authentication not configured".to_string())
@@ -743,8 +761,15 @@ where
 
             Ok(event)
         } else {
-            // Relay path: we are not a member, relay to a member node with failover.
-            let members = network.member_nodes_as_strings();
+            // Relay path: we don't hold the genesis, so relay to a member that
+            // does, with failover. Exclude ourselves: a promoted-but-unsynced
+            // member is in its own member set, and relaying to self would just
+            // waste a failover attempt (mirrors the self-skip on the push path).
+            let members: Vec<String> = network
+                .member_nodes_as_strings()
+                .into_iter()
+                .filter(|m| m != &self.local_node_id)
+                .collect();
             if members.is_empty() {
                 return Err(StateNodeError::NoAvailableMembers);
             }
@@ -807,9 +832,10 @@ where
             .map_err(|e| StateNodeError::StorageError(e.to_string()))?
             .ok_or_else(|| StateNodeError::ContentNotFound(content_id_vo.clone()))?;
 
-        // 2. Check if local node is a member
-        if network.has_member_str(&self.local_node_id) {
-            // Local update path: we are a member node
+        // 2. Decide local commit vs relay by genesis presence (not membership):
+        //    only a node that actually holds the CRDT genesis can update locally.
+        if self.can_commit_locally(content_id).await {
+            // Local update path: we hold the genesis
             // Authenticate and authorize locally (we have the up-to-date access policy)
             let auth_service = self.auth_service.as_ref().ok_or_else(|| {
                 StateNodeError::InvalidConfiguration("Authentication not configured".to_string())
@@ -888,8 +914,15 @@ where
 
             Ok(event)
         } else {
-            // Relay path: we are not a member, relay to a member node with failover.
-            let members = network.member_nodes_as_strings();
+            // Relay path: we don't hold the genesis, so relay to a member that
+            // does, with failover. Exclude ourselves: a promoted-but-unsynced
+            // member is in its own member set, and relaying to self would just
+            // waste a failover attempt (mirrors the self-skip on the push path).
+            let members: Vec<String> = network
+                .member_nodes_as_strings()
+                .into_iter()
+                .filter(|m| m != &self.local_node_id)
+                .collect();
             if members.is_empty() {
                 return Err(StateNodeError::NoAvailableMembers);
             }
@@ -994,8 +1027,10 @@ where
             .map_err(|e| StateNodeError::StorageError(e.to_string()))?
             .ok_or_else(|| StateNodeError::ContentNotFound(content_id_vo.clone()))?;
 
-        if network.has_member_str(&self.local_node_id) {
-            // Local path: we are a member node
+        // Decide local commit vs relay by genesis presence (not membership):
+        // only a node that actually holds the CRDT genesis can invalidate locally.
+        if self.can_commit_locally(content_id).await {
+            // Local path: we hold the genesis
             // 4. Get access policy from CRDT
             let mut policy = self
                 .crdt_repo
@@ -1074,8 +1109,15 @@ where
 
             Ok(new_min)
         } else {
-            // Relay path: we are not a member, relay to a member node
-            let members = network.member_nodes_as_strings();
+            // Relay path: we don't hold the genesis, so relay to a member that
+            // does. Exclude ourselves: a promoted-but-unsynced member is in its
+            // own member set, and relaying to self would just waste a failover
+            // attempt (mirrors the self-skip on the push path above).
+            let members: Vec<String> = network
+                .member_nodes_as_strings()
+                .into_iter()
+                .filter(|m| m != &self.local_node_id)
+                .collect();
             if members.is_empty() {
                 return Err(StateNodeError::NoAvailableMembers);
             }
@@ -1544,7 +1586,16 @@ where
                 member_nodes,
                 ..
             } => {
-                // Only store network metadata if we're a member
+                // Only store network metadata if we're a member.
+                //
+                // Being listed as a member here is always safe to accept: the
+                // local-vs-relay decision for writes is made by genesis
+                // presence (see `can_commit_locally`), not by membership. A
+                // member that has not yet synced the genesis simply relays its
+                // writes until the genesis arrives, so there is no need to
+                // refuse promotion. This also lets the original create_content
+                // relay node become a real member later if it is re-selected
+                // and syncs the genesis.
                 if !member_nodes.contains(&self.local_node_id) {
                     return Ok(ApplyOutcome::Ignored);
                 }
@@ -2654,6 +2705,143 @@ mod tests {
 
         let outcome = service.handle_sync_event(&event, None).await.unwrap();
         assert_eq!(outcome, ApplyOutcome::Ignored);
+    }
+
+    // The node that first handled create_content keeps a local ContentNetwork
+    // record in which it is NOT a member (it is a non-member relay holding no
+    // genesis). If a later redundancy check re-selects it and broadcasts
+    // ContentNetworkManagerAdded with it in the member set, promotion is now
+    // ACCEPTED — membership no longer drives the local-vs-relay write decision
+    // (genesis presence does, see can_commit_locally), so being a member while
+    // lacking the genesis is safe. Writes simply relay until the genesis syncs.
+    #[tokio::test]
+    async fn test_content_network_manager_added_promotes_former_relay_node() {
+        // Seed a local record where node-1 (us) is currently a non-member relay:
+        // the network it remembers contains only node-2 and node-3.
+        let node_registry = MockNodeRegistry::new();
+        let content_repo = Arc::new(RwLock::new(
+            MockContentNetworkRepository::new()
+                .with_network(create_test_network("content-1", vec!["node-2", "node-3"])),
+        ));
+        let peer_network = Arc::new(MockPeerNetwork::new().with_local_peer_id("node-1"));
+        let event_publisher = MockEventPublisher::new();
+        let crdt_repo = Arc::new(MockContentRepository::new());
+
+        let service: TestService = StateNodeService::new(
+            node_registry,
+            content_repo,
+            peer_network,
+            event_publisher,
+            crdt_repo,
+            "node-1".to_string(),
+        )
+        .with_authentication_service(TestAuthService)
+        .with_authorization_service(AllowAllAuthorizationService);
+
+        // A redundancy check on another node added us (node-1) to the member set.
+        let event = Event::ContentNetworkManagerAdded {
+            content_id: "content-1".to_string(),
+            added_node_id: "node-1".to_string(),
+            member_nodes: vec![
+                "node-1".to_string(),
+                "node-2".to_string(),
+                "node-3".to_string(),
+            ],
+            timestamp: 12345,
+        };
+
+        let outcome = service.handle_sync_event(&event, None).await.unwrap();
+        // Promotion is accepted (not Ignored): the former relay becomes a member.
+        assert_eq!(
+            outcome,
+            ApplyOutcome::NeedsSync {
+                content_id: "content-1".to_string(),
+            }
+        );
+
+        // The local record now lists node-1 as a member.
+        let network = service
+            .get_content_network_for_test("content-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(network.has_member_str("node-1"));
+    }
+
+    // The core invariant of the genesis-based routing: a node that IS a member
+    // of the ContentNetwork but does NOT yet hold the CRDT genesis must relay
+    // its writes rather than commit locally. Committing locally without the
+    // genesis is exactly what produced the "Genesis not found" HTTP 500. This
+    // covers both the create_content relay node and a freshly added member that
+    // has not synced the genesis yet.
+    #[tokio::test]
+    async fn test_update_relays_when_member_but_genesis_absent() {
+        let node_registry = MockNodeRegistry::new();
+        // node-1 (us) IS listed as a member alongside node-2.
+        let content_repo = Arc::new(RwLock::new(
+            MockContentNetworkRepository::new()
+                .with_network(create_test_network("content-1", vec!["node-1", "node-2"])),
+        ));
+        // Keep a handle to the peer network so we can assert the relay path was
+        // actually taken (not just that the call returned Ok — the mock CRDT
+        // repo would happily "commit" locally without a genesis, so observing
+        // the relay invocation is the only way to distinguish the two paths).
+        let peer_network = Arc::new(MockPeerNetwork::new().with_local_peer_id("node-1"));
+        let event_publisher = MockEventPublisher::new();
+        // CRDT repo is empty: we hold no genesis for content-1, so a local
+        // commit would (in production) fail with "Genesis not found".
+        let crdt_repo = Arc::new(MockContentRepository::new());
+
+        let service: TestService = StateNodeService::new(
+            node_registry,
+            content_repo,
+            peer_network.clone(),
+            event_publisher,
+            crdt_repo,
+            "node-1".to_string(),
+        )
+        .with_authentication_service(TestAuthService)
+        .with_authorization_service(AllowAllAuthorizationService);
+
+        // Despite being a member, the write must relay (and succeed) because we
+        // lack the genesis — not commit locally.
+        let result = service
+            .update_content(
+                "content-1",
+                b"new data",
+                Some(&test_token()),
+                Some(&test_request_signature()),
+                None,
+            )
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "member-without-genesis must relay successfully, got: {:?}",
+            result.err()
+        );
+        // The discriminating assertion: the relay path was taken exactly because
+        // the genesis was absent. If routing reverted to membership-based, this
+        // would be 0 (the node would have committed locally).
+        assert_eq!(
+            *peer_network.relay_update_calls.lock().await,
+            1,
+            "expected the update to be relayed once due to missing genesis",
+        );
+        // And it must never relay to itself: node-1 is in its own member set
+        // (it was promoted) but holds no genesis, so the only valid relay
+        // target is node-2. Relaying to self would waste a failover attempt.
+        let targets = peer_network.relay_update_peers.lock().await.clone();
+        assert!(
+            !targets.contains(&"node-1".to_string()),
+            "must not relay to self (node-1); relayed to: {:?}",
+            targets
+        );
+        assert_eq!(
+            targets,
+            vec!["node-2".to_string()],
+            "relay must target the other member only",
+        );
     }
 
     #[tokio::test]

--- a/monas-state-node/src/test_utils.rs
+++ b/monas-state-node/src/test_utils.rs
@@ -37,6 +37,16 @@ pub struct MockPeerNetwork {
     pub relay_update_result: Arc<Mutex<Option<bool>>>,
     pub relay_delete_result: Arc<Mutex<Option<bool>>>,
     pub relay_invalidate_tokens_result: Arc<Mutex<Option<bool>>>,
+    /// Number of times each relay method was invoked. Lets tests assert that a
+    /// write actually took the relay path (vs committing locally).
+    pub relay_update_calls: Arc<Mutex<usize>>,
+    pub relay_delete_calls: Arc<Mutex<usize>>,
+    pub relay_invalidate_tokens_calls: Arc<Mutex<usize>>,
+    /// Target peer ids each relay method was invoked with, in order. Lets tests
+    /// assert which members a write was relayed to (e.g. never to self).
+    pub relay_update_peers: Arc<Mutex<Vec<String>>>,
+    pub relay_delete_peers: Arc<Mutex<Vec<String>>>,
+    pub relay_invalidate_tokens_peers: Arc<Mutex<Vec<String>>>,
 }
 
 impl MockPeerNetwork {
@@ -52,6 +62,12 @@ impl MockPeerNetwork {
             relay_update_result: Arc::new(Mutex::new(Some(true))),
             relay_delete_result: Arc::new(Mutex::new(Some(true))),
             relay_invalidate_tokens_result: Arc::new(Mutex::new(Some(true))),
+            relay_update_calls: Arc::new(Mutex::new(0)),
+            relay_delete_calls: Arc::new(Mutex::new(0)),
+            relay_invalidate_tokens_calls: Arc::new(Mutex::new(0)),
+            relay_update_peers: Arc::new(Mutex::new(Vec::new())),
+            relay_delete_peers: Arc::new(Mutex::new(Vec::new())),
+            relay_invalidate_tokens_peers: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -198,35 +214,50 @@ impl PeerNetwork for MockPeerNetwork {
 
     async fn relay_update_content(
         &self,
-        _peer_id: &str,
+        peer_id: &str,
         _content_id: &str,
         _data: &[u8],
         _auth_token: &str,
         _request_signature: &[u8],
         _timestamp: Option<u64>,
     ) -> Result<bool> {
+        *self.relay_update_calls.lock().await += 1;
+        self.relay_update_peers
+            .lock()
+            .await
+            .push(peer_id.to_string());
         Ok(self.relay_update_result.lock().await.unwrap_or(true))
     }
 
     async fn relay_delete_content(
         &self,
-        _peer_id: &str,
+        peer_id: &str,
         _content_id: &str,
         _auth_token: &str,
         _request_signature: &[u8],
         _timestamp: Option<u64>,
     ) -> Result<bool> {
+        *self.relay_delete_calls.lock().await += 1;
+        self.relay_delete_peers
+            .lock()
+            .await
+            .push(peer_id.to_string());
         Ok(self.relay_delete_result.lock().await.unwrap_or(true))
     }
 
     async fn relay_invalidate_tokens(
         &self,
-        _peer_id: &str,
+        peer_id: &str,
         _content_id: &str,
         _auth_token: &str,
         _request_signature: &[u8],
         _timestamp: Option<u64>,
     ) -> Result<bool> {
+        *self.relay_invalidate_tokens_calls.lock().await += 1;
+        self.relay_invalidate_tokens_peers
+            .lock()
+            .await
+            .push(peer_id.to_string());
         Ok(self
             .relay_invalidate_tokens_result
             .lock()


### PR DESCRIPTION
## 背景 / Problem

creator ノード(content 作成リクエストを最初に受けた state node)に対する `invalidate_tokens`(および `update`/`delete`)が **HTTP 500**(`Failed to commit access policy update: internal error: Genesis not found`)を返すバグを修正します。

creator は設計上 **CRDT 非メンバー**で genesis を持たない中継役です。にもかかわらず、書き込みの local/relay 分岐が **メンバーシップ**で判定されていたため、creator が自分の content network のメンバーとして記録されると(self-promotion)、genesis を持たないまま local commit 経路に入り `commit_operation` が genesis 不在で失敗していました。

### 失敗の連鎖(コードで裏取り済み)
1. `create_content`: creator A は「メンバー集合は記憶するが自分は非メンバー」のローカル ContentNetwork を保存。genesis は持たない。
2. 後続の更新で、メンバーノード B の redundancy check(`check_and_maintain_redundancy` → `add_member_to_content_internal`)が `find_closest_peers` で新メンバーを選ぶ際、**既存メンバーのみ除外し creator を除外しない**。creator A は DHT 最近傍なので選ばれ、`ContentNetworkManagerAdded`(member_nodes に A を含む)が broadcast される。
3. A の sync ハンドラが「member_nodes に自分が含まれる」ため自分をメンバーとして保存(self-promotion)。
4. その後の `invalidate`/`update`/`delete` が `has_member_str(A)=true` で **local path** に入り、genesis 不在の `commit_operation` が "Genesis not found" → 500。

## 修正: 書き込みのルーティングを「メンバーシップ」から「genesis の有無」へ

500 の真因は *genesis を持たないノードが local commit に入る* ことです。そこでメンバーシップではなく、**このノードが実際に CRDT genesis を保持しているか**で local commit / relay を分岐します。

- `can_commit_locally(content_id)` ヘルパを追加(`crdt_repo.exists(genesis)` をラップ)。
- `update` / `delete` / `invalidate_tokens` の3経路の分岐を `network.has_member_str(self)` → `can_commit_locally(content_id)` に変更。
- **genesis を持つノードだけが local commit**。持たないノード(create_content の中継役、あるいは昇格直後で genesis 未 sync のメンバー)は relay path で genesis 保有メンバーに委譲して 200 を返す。genesis を sync 取得すれば、以降は自分で local commit できる。
- これに伴い **self-promotion ガードを撤廃**。メンバー昇格は常に受け入れてよい(メンバーであっても genesis が無ければ relay するだけなので安全)。結果として、create の中継役だったノードも、後で再選定され genesis を sync すれば正規メンバーに昇格できる。
- 昇格を受け入れる結果、**「メンバーだが genesis 未 sync」のノードは自分自身を member 集合に含む**ため、relay 先候補に自分が混ざる。これを防ぐため **relay 候補から自ノードを除外**(3経路とも `members` から `self.local_node_id` を filter)。既存の push 経路の self-skip と対称化。除外しないと、自分宛 relay を試みて failover を1回分無駄にする(libp2p の自ノード宛 send_request は配送されず失敗するため無限ループにはならないが非効率)。これは self-promotion ガード撤廃で顕在化した副作用で、本PR内で併せて解消。

### プライバシー / プロトコル思想
判定は **各ノードのローカル CRDT 状態(genesis の有無)のみ**で行います。旧アプローチの「ローカルレコードがあり自分が非メンバー → creator と判定」は、ノードが自分が creator であることを内部状態から復元する形になっており、creator 匿名性の縁に触れていました。本アプローチでは **「誰が creator か」という概念をコードのどこにも持たず、保存・参照・伝播もしません**。メンバー集合は creator/非creator を区別しません。

### 副次的な正しさ
メンバーシップ判定では「メンバー昇格直後・genesis 未 sync」の瞬間に書き込むと 500 になり得ましたが、genesis 判定はこのケースも自然に救います(genesis 到着まで relay)。

## 検証

`cargo test -p monas-state-node` 全 green(289 unit + 32 integration + 5 e2e + 4 public-key)。`cargo clippy --all-targets` 警告なし。

新規/更新したユニットテストは、いずれも **ネガティブコントロール(判定ロジックを意図的に壊すと落ちる)を確認済み**:
- `test_content_network_manager_added_promotes_former_relay_node`: 旧中継役ノードが昇格を受理し member になる(`NeedsSync`)。self-promotion ガードを戻すと `Ignored` になり落ちる。
- `test_update_relays_when_member_but_genesis_absent`: member だが genesis 未保持のとき relay path を通り、**かつ自分自身には relay しない**。**relay 先 peer を直接観測**(mock の CRDT repo は genesis 不在でも commit を Ok にしてしまうため、結果だけでは local/relay を区別できない。`MockPeerNetwork` に relay 呼び出し回数 + 宛先 peer の記録を追加して経路を直接 assert)。genesis 判定を壊すと relay 回数 0、self 除外を外すと relay 先が自分(`["node-1"]`)になり、いずれも落ちる。
- 既存の `test_update_content_success`(member かつ genesis 保持 → local)/ `test_update_content_relay_when_not_member`(非member かつ genesis 非保持 → relay)も回帰なし。

## 関連 / 注意
- 4ノードでのフル e2e 検証には **DialFailure 修正(#48)** が前提です(無いと content 作成自体が 408 になる)。#48 を先にマージ後、本ブランチをリベースして CI の e2e を通すのが順序です。
- `crsl_lib` の "Genesis not found" / "cycle detected in graph"(部分 DAG import の症状)自体は **本PRのスコープ外**。本修正は genesis を持たないノードを local commit 経路に入れないことで 500 を解消します。
- redundancy check(選定側)が creator を候補に含めうる点は変更していません。`ContentNetwork` ドメイン型は creator フィールドを持たず、選定ノードは creator が誰か**知り得ない**ため、選定側で creator を除外するには creator identity の伝播が必要で、それは匿名性設計に反します(=選定側除外は不採用)。再選定されたノードは genesis を sync して正規メンバーになれるため、本修正の前提では問題になりません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

