### PR TITLE
fix(state-node): discover members via DHT for relay and read (#93)

### DIFF
--- a/monas-state-node/src/application_service/node.rs
+++ b/monas-state-node/src/application_service/node.rs
@@ -356,7 +356,7 @@ impl StateNode {
                                 } => {
                                     let token = AuthToken::new(auth_token);
                                     service_for_relay
-                                        .update_content(
+                                        .update_content_via_relay(
                                             &content_id,
                                             &data,
                                             Some(&token),
@@ -374,7 +374,7 @@ impl StateNode {
                                 } => {
                                     let token = AuthToken::new(auth_token);
                                     service_for_relay
-                                        .delete_content(
+                                        .delete_content_via_relay(
                                             &content_id,
                                             Some(&token),
                                             Some(&request_signature),
@@ -391,7 +391,7 @@ impl StateNode {
                                 } => {
                                     let token = AuthToken::new(auth_token);
                                     service_for_relay
-                                        .invalidate_tokens(
+                                        .invalidate_tokens_via_relay(
                                             &content_id,
                                             &token,
                                             Some(&request_signature),

--- a/monas-state-node/src/application_service/state_node_service.rs
+++ b/monas-state-node/src/application_service/state_node_service.rs
@@ -407,6 +407,121 @@ where
         Err(StateNodeError::NoAvailableMembers)
     }
 
+    /// Resolve the member nodes that own a content, for relay/sync purposes.
+    ///
+    /// If we hold a local `ContentNetwork` record, return its member set
+    /// (current behaviour). If we do not — e.g. a client sent a request to a
+    /// node that was neither the creator nor a member — fall back to DHT
+    /// discovery using the same key function and replication factor that
+    /// `create_content` used to place the content (`compute_dht_key` +
+    /// `min_replication_factor`). This lets any node relay a request to the
+    /// real members instead of returning `ContentNotFound` (bug #93).
+    ///
+    /// The local node is always excluded from the result. Returns
+    /// `NoAvailableMembers` if no candidate remains.
+    async fn resolve_members(&self, content_id: &str) -> Result<Vec<String>, StateNodeError> {
+        let local_record = self
+            .content_repo
+            .read()
+            .await
+            .get_content_network(content_id)
+            .await
+            .map_err(|e| StateNodeError::StorageError(e.to_string()))?;
+
+        let mut members: Vec<String> = match local_record {
+            Some(network) => network.member_nodes_as_strings(),
+            None => {
+                // No local record: discover the members via the DHT. Request
+                // `k + 1` candidates so that excluding ourselves still leaves
+                // up to `k`, mirroring create_content's placement.
+                let key = compute_dht_key(content_id);
+                self.peer_network
+                    .find_closest_peers(key, self.min_replication_factor + 1)
+                    .await
+                    .map_err(|e| {
+                        StateNodeError::NetworkError(NetworkError::ConnectionFailed(e.to_string()))
+                    })?
+            }
+        };
+
+        members.retain(|peer| peer != &self.local_node_id);
+        if members.is_empty() {
+            return Err(StateNodeError::NoAvailableMembers);
+        }
+        Ok(members)
+    }
+
+    /// Ensure the content's CRDT state is available locally, fetching it from
+    /// member nodes if necessary (bug #93, read side).
+    ///
+    /// Read endpoints (data / history / version) read straight from the local
+    /// `crdt_repo`. A node that holds no local state for a content — e.g. a
+    /// client pointed its gateway at a node that is neither the creator nor a
+    /// member — would otherwise 404. This pulls the operations from a member
+    /// (discovered via `resolve_members`) and applies them locally so the
+    /// existing read path works unchanged. Applying the operations also brings
+    /// in the access policy, so the subsequent `verify_read_access` check is
+    /// evaluated against the real policy rather than an empty one.
+    ///
+    /// No-op when we already have local history. Returns `ContentNotFound` if
+    /// no member could supply the operations.
+    ///
+    /// SECURITY NOTE: this reuses the unauthenticated `fetch_operations` RPC,
+    /// so a non-member can pull any content's operations. Acceptable for the
+    /// single-user demo; a hardened version should add a read-relay RPC with
+    /// member-side authorization. Tracked in bug #93 follow-up.
+    pub async fn ensure_content_local(&self, content_id: &str) -> Result<(), StateNodeError> {
+        // Fast path: we already hold local history for this content.
+        let has_local = self
+            .crdt_repo
+            .get_history(content_id)
+            .await
+            .map(|h| !h.is_empty())
+            .unwrap_or(false);
+        if has_local {
+            return Ok(());
+        }
+
+        // Discover the members (local record, or DHT fallback) and pull ops.
+        let members = self.resolve_members(content_id).await?;
+        let content_id_vo = ContentId::new(content_id.to_string())?;
+
+        for member in &members {
+            match self
+                .peer_network
+                .fetch_operations(member, content_id, None)
+                .await
+            {
+                Ok(ops) if !ops.is_empty() => {
+                    match self.crdt_repo.apply_operations(&ops).await {
+                        Ok(_) => return Ok(()),
+                        Err(e) => {
+                            tracing::warn!(
+                                "ensure_content_local: failed to apply ops from {} for {}: {}",
+                                member,
+                                content_id,
+                                e
+                            );
+                        }
+                    }
+                }
+                Ok(_) => {
+                    // Member returned no operations; try the next one.
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "ensure_content_local: failed to fetch ops from {} for {}: {}",
+                        member,
+                        content_id,
+                        e
+                    );
+                }
+            }
+        }
+
+        Err(StateNodeError::ContentNotFound(content_id_vo))
+    }
+
     /// Register a new node.
     ///
     /// This publishes the NodeCreated event both locally and to the network.
@@ -651,6 +766,32 @@ where
         request_signature: Option<&[u8]>,
         timestamp: Option<u64>,
     ) -> Result<Event, StateNodeError> {
+        self.delete_content_inner(content_id, token, request_signature, timestamp, false)
+            .await
+    }
+
+    /// Entry point for `delete` requests that arrived via relay from another
+    /// node. Identical to [`delete_content`] except that it will not relay
+    /// again — enforcing a 1-hop relay limit to prevent cycles (bug #93).
+    pub async fn delete_content_via_relay(
+        &self,
+        content_id: &str,
+        token: Option<&AuthToken>,
+        request_signature: Option<&[u8]>,
+        timestamp: Option<u64>,
+    ) -> Result<Event, StateNodeError> {
+        self.delete_content_inner(content_id, token, request_signature, timestamp, true)
+            .await
+    }
+
+    async fn delete_content_inner(
+        &self,
+        content_id: &str,
+        token: Option<&AuthToken>,
+        request_signature: Option<&[u8]>,
+        timestamp: Option<u64>,
+        from_relay: bool,
+    ) -> Result<Event, StateNodeError> {
         let token = token.ok_or_else(|| {
             StateNodeError::AuthenticationFailed("Authentication token is required".to_string())
         })?;
@@ -658,7 +799,9 @@ where
             StateNodeError::AuthenticationFailed("Request signature is required".to_string())
         })?;
 
-        // 1. Verify content network exists
+        // 1. Look up the content network. Unlike before, a missing record is
+        //    not an immediate 404: a non-member node can still relay to the
+        //    real members discovered via the DHT (bug #93).
         let content_id_vo = ContentId::new(content_id.to_string())?;
         let network = self
             .content_repo
@@ -666,11 +809,13 @@ where
             .await
             .get_content_network(content_id)
             .await
-            .map_err(|e| StateNodeError::StorageError(e.to_string()))?
-            .ok_or_else(|| StateNodeError::ContentNotFound(content_id_vo.clone()))?;
+            .map_err(|e| StateNodeError::StorageError(e.to_string()))?;
 
         // 2. Check if local node is a member
-        if network.has_member_str(&self.local_node_id) {
+        let is_member = network
+            .as_ref()
+            .is_some_and(|n| n.has_member_str(&self.local_node_id));
+        if is_member {
             // Local delete path: we are a member node
             // Authenticate and authorize locally (we have the up-to-date access policy)
             let auth_service = self.auth_service.as_ref().ok_or_else(|| {
@@ -743,11 +888,19 @@ where
 
             Ok(event)
         } else {
-            // Relay path: we are not a member, relay to a member node with failover.
-            let members = network.member_nodes_as_strings();
-            if members.is_empty() {
-                return Err(StateNodeError::NoAvailableMembers);
+            // Relay path: we are not a member.
+            //
+            // 1-hop limit: if this request itself arrived via relay, do not
+            // relay again — the previous hop already resolved members, so a
+            // non-member receiver here means the chosen member was wrong.
+            // Refusing to re-relay prevents relay cycles (bug #93).
+            if from_relay {
+                return Err(StateNodeError::ContentNotFound(content_id_vo.clone()));
             }
+
+            // Resolve members from our local record, or via DHT discovery when
+            // we hold no record (bug #93), then relay with failover.
+            let members = self.resolve_members(content_id).await?;
 
             let token_str = token.as_str().to_string();
             let content_id_owned = content_id.to_string();
@@ -789,6 +942,35 @@ where
         request_signature: Option<&[u8]>,
         timestamp: Option<u64>,
     ) -> Result<Event, StateNodeError> {
+        self.update_content_inner(content_id, data, token, request_signature, timestamp, false)
+            .await
+    }
+
+    /// Entry point for `update` requests that arrived via relay from another
+    /// node. Identical to [`update_content`] except that it will not relay
+    /// again — enforcing a 1-hop relay limit to prevent cycles (bug #93).
+    pub async fn update_content_via_relay(
+        &self,
+        content_id: &str,
+        data: &[u8],
+        token: Option<&AuthToken>,
+        request_signature: Option<&[u8]>,
+        timestamp: Option<u64>,
+    ) -> Result<Event, StateNodeError> {
+        self.update_content_inner(content_id, data, token, request_signature, timestamp, true)
+            .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn update_content_inner(
+        &self,
+        content_id: &str,
+        data: &[u8],
+        token: Option<&AuthToken>,
+        request_signature: Option<&[u8]>,
+        timestamp: Option<u64>,
+        from_relay: bool,
+    ) -> Result<Event, StateNodeError> {
         let token = token.ok_or_else(|| {
             StateNodeError::AuthenticationFailed("Authentication token is required".to_string())
         })?;
@@ -796,7 +978,9 @@ where
             StateNodeError::AuthenticationFailed("Request signature is required".to_string())
         })?;
 
-        // 1. Verify content network exists
+        // 1. Look up the content network. A missing record is not an immediate
+        //    404: a non-member node can still relay to the real members
+        //    discovered via the DHT (bug #93).
         let content_id_vo = ContentId::new(content_id.to_string())?;
         let network = self
             .content_repo
@@ -804,11 +988,13 @@ where
             .await
             .get_content_network(content_id)
             .await
-            .map_err(|e| StateNodeError::StorageError(e.to_string()))?
-            .ok_or_else(|| StateNodeError::ContentNotFound(content_id_vo.clone()))?;
+            .map_err(|e| StateNodeError::StorageError(e.to_string()))?;
 
         // 2. Check if local node is a member
-        if network.has_member_str(&self.local_node_id) {
+        let is_member = network
+            .as_ref()
+            .is_some_and(|n| n.has_member_str(&self.local_node_id));
+        if is_member {
             // Local update path: we are a member node
             // Authenticate and authorize locally (we have the up-to-date access policy)
             let auth_service = self.auth_service.as_ref().ok_or_else(|| {
@@ -888,11 +1074,16 @@ where
 
             Ok(event)
         } else {
-            // Relay path: we are not a member, relay to a member node with failover.
-            let members = network.member_nodes_as_strings();
-            if members.is_empty() {
-                return Err(StateNodeError::NoAvailableMembers);
+            // Relay path: we are not a member.
+            //
+            // 1-hop limit: a relayed request must not be relayed again (bug #93).
+            if from_relay {
+                return Err(StateNodeError::ContentNotFound(content_id_vo.clone()));
             }
+
+            // Resolve members from our local record, or via DHT discovery when
+            // we hold no record (bug #93), then relay with failover.
+            let members = self.resolve_members(content_id).await?;
 
             let token_str = token.as_str().to_string();
             let content_id_owned = content_id.to_string();
@@ -949,6 +1140,32 @@ where
         request_signature: Option<&[u8]>,
         timestamp: Option<u64>,
     ) -> Result<u64, StateNodeError> {
+        self.invalidate_tokens_inner(content_id, token, request_signature, timestamp, false)
+            .await
+    }
+
+    /// Entry point for `invalidate_tokens` requests that arrived via relay from
+    /// another node. Identical to [`invalidate_tokens`] except that it will not
+    /// relay again — enforcing a 1-hop relay limit to prevent cycles (bug #93).
+    pub async fn invalidate_tokens_via_relay(
+        &self,
+        content_id: &str,
+        token: &AuthToken,
+        request_signature: Option<&[u8]>,
+        timestamp: Option<u64>,
+    ) -> Result<u64, StateNodeError> {
+        self.invalidate_tokens_inner(content_id, token, request_signature, timestamp, true)
+            .await
+    }
+
+    async fn invalidate_tokens_inner(
+        &self,
+        content_id: &str,
+        token: &AuthToken,
+        request_signature: Option<&[u8]>,
+        timestamp: Option<u64>,
+        from_relay: bool,
+    ) -> Result<u64, StateNodeError> {
         // 1. Ensure auth services are configured
         let auth_service = self.auth_service.as_ref().ok_or_else(|| {
             StateNodeError::InvalidConfiguration("Authentication not configured".to_string())
@@ -983,7 +1200,9 @@ where
         )
         .await?;
 
-        // 3. Check if this node is a member
+        // 3. Check if this node is a member. A missing record is not an
+        //    immediate 404: a non-member node can still relay to the real
+        //    members discovered via the DHT (bug #93).
         let content_id_vo = ContentId::new(content_id.to_string())?;
         let network = self
             .content_repo
@@ -991,10 +1210,13 @@ where
             .await
             .get_content_network(content_id)
             .await
-            .map_err(|e| StateNodeError::StorageError(e.to_string()))?
-            .ok_or_else(|| StateNodeError::ContentNotFound(content_id_vo.clone()))?;
+            .map_err(|e| StateNodeError::StorageError(e.to_string()))?;
 
-        if network.has_member_str(&self.local_node_id) {
+        let is_member = network
+            .as_ref()
+            .is_some_and(|n| n.has_member_str(&self.local_node_id));
+        if is_member {
+            let network = network.expect("is_member implies Some");
             // Local path: we are a member node
             // 4. Get access policy from CRDT
             let mut policy = self
@@ -1074,11 +1296,16 @@ where
 
             Ok(new_min)
         } else {
-            // Relay path: we are not a member, relay to a member node
-            let members = network.member_nodes_as_strings();
-            if members.is_empty() {
-                return Err(StateNodeError::NoAvailableMembers);
+            // Relay path: we are not a member.
+            //
+            // 1-hop limit: a relayed request must not be relayed again (bug #93).
+            if from_relay {
+                return Err(StateNodeError::ContentNotFound(content_id_vo.clone()));
             }
+
+            // Resolve members from our local record, or via DHT discovery when
+            // we hold no record (bug #93), then relay with failover.
+            let members = self.resolve_members(content_id).await?;
 
             let token_str = token.as_str().to_string();
             let content_id_owned = content_id.to_string();
@@ -2366,7 +2593,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_update_content_fails_if_network_not_found() {
+    async fn test_update_content_no_record_no_discoverable_members_errors() {
+        // With bug #93 fixed, a node holding no ContentNetwork record no longer
+        // 404s immediately — it tries to discover the members via the DHT. When
+        // discovery yields no peers (default mock), it reports NoAvailableMembers
+        // rather than ContentNotFound.
         let service = create_test_service("node-1");
 
         let result = service
@@ -2383,7 +2614,152 @@ mod tests {
         assert!(result
             .unwrap_err()
             .to_string()
-            .contains("Content not found"));
+            .contains("No available member nodes"));
+    }
+
+    #[tokio::test]
+    async fn test_update_content_no_record_relays_to_discovered_members() {
+        // Bug #93: a node that holds no ContentNetwork record must still relay
+        // the update to members discovered via the DHT, instead of 404ing.
+        let service = create_service_with_peers(
+            "node-1",
+            vec!["node-2".to_string(), "node-3".to_string()],
+            HashMap::new(),
+        );
+
+        let result = service
+            .update_content(
+                "content-1",
+                b"data",
+                Some(&test_token()),
+                Some(&test_request_signature()),
+                None,
+            )
+            .await;
+
+        assert!(result.is_ok(), "expected relay success, got {result:?}");
+        match result.unwrap() {
+            Event::ContentUpdated {
+                content_id,
+                updated_node_id,
+                ..
+            } => {
+                assert_eq!(content_id, "content-1");
+                assert_eq!(updated_node_id, "node-1");
+            }
+            other => panic!("Expected ContentUpdated event, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_delete_content_no_record_relays_to_discovered_members() {
+        // Bug #93: delete must also relay to DHT-discovered members.
+        let service = create_service_with_peers(
+            "node-1",
+            vec!["node-2".to_string(), "node-3".to_string()],
+            HashMap::new(),
+        );
+
+        let result = service
+            .delete_content(
+                "content-1",
+                Some(&test_token()),
+                Some(&test_request_signature()),
+                None,
+            )
+            .await;
+
+        assert!(result.is_ok(), "expected relay success, got {result:?}");
+        match result.unwrap() {
+            Event::ContentDeleted {
+                content_id,
+                deleted_by_node_id,
+                ..
+            } => {
+                assert_eq!(content_id, "content-1");
+                assert_eq!(deleted_by_node_id, "node-1");
+            }
+            other => panic!("Expected ContentDeleted event, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_update_via_relay_does_not_re_relay_when_not_member() {
+        // Bug #93 1-hop guard: a request that arrived via relay must NOT be
+        // relayed again. A non-member receiver of a relayed update returns
+        // ContentNotFound instead of forwarding (which would risk a cycle).
+        let service = create_service_with_peers(
+            "node-1",
+            vec!["node-2".to_string(), "node-3".to_string()],
+            HashMap::new(),
+        );
+
+        let result = service
+            .update_content_via_relay(
+                "content-1",
+                b"data",
+                Some(&test_token()),
+                Some(&test_request_signature()),
+                None,
+            )
+            .await;
+
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().to_string().contains("Content not found"),
+            "relayed request to a non-member must not re-relay"
+        );
+    }
+
+    fn sample_operation(genesis_cid: &str) -> crate::port::content_repository::SerializedOperation {
+        crate::port::content_repository::SerializedOperation {
+            data: vec![0x01, 0x02],
+            genesis_cid: genesis_cid.to_string(),
+            author: "node-2".to_string(),
+            timestamp: 1,
+            node_timestamp: 1,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_ensure_content_local_pulls_from_discovered_member() {
+        // Bug #93 (read side): a node with no local state for the content must
+        // pull the operations from a DHT-discovered member and apply them
+        // locally so the read endpoints work instead of 404ing.
+        let node_registry = MockNodeRegistry::new();
+        let content_repo = Arc::new(RwLock::new(MockContentNetworkRepository::new()));
+        let peer_network = Arc::new(
+            MockPeerNetwork::new()
+                .with_local_peer_id("node-1")
+                .with_closest_peers(vec!["node-2".to_string()])
+                .with_fetched_operations(vec![sample_operation("content-1")]),
+        );
+        let event_publisher = MockEventPublisher::new();
+        let crdt_repo = Arc::new(MockContentRepository::new());
+
+        let service: TestService = StateNodeService::new(
+            node_registry,
+            content_repo,
+            peer_network,
+            event_publisher,
+            crdt_repo,
+            "node-1".to_string(),
+        );
+
+        let result = service.ensure_content_local("content-1").await;
+        assert!(result.is_ok(), "expected ops pull to succeed, got {result:?}");
+    }
+
+    #[tokio::test]
+    async fn test_ensure_content_local_errors_when_no_member_has_data() {
+        // No discoverable members → cannot pull → ContentNotFound.
+        let service = create_test_service("node-1");
+        let result = service.ensure_content_local("content-1").await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("No available member nodes"));
     }
 
     #[tokio::test]

--- a/monas-state-node/src/application_service/state_node_service.rs
+++ b/monas-state-node/src/application_service/state_node_service.rs
@@ -492,19 +492,17 @@ where
                 .fetch_operations(member, content_id, None)
                 .await
             {
-                Ok(ops) if !ops.is_empty() => {
-                    match self.crdt_repo.apply_operations(&ops).await {
-                        Ok(_) => return Ok(()),
-                        Err(e) => {
-                            tracing::warn!(
-                                "ensure_content_local: failed to apply ops from {} for {}: {}",
-                                member,
-                                content_id,
-                                e
-                            );
-                        }
+                Ok(ops) if !ops.is_empty() => match self.crdt_repo.apply_operations(&ops).await {
+                    Ok(_) => return Ok(()),
+                    Err(e) => {
+                        tracing::warn!(
+                            "ensure_content_local: failed to apply ops from {} for {}: {}",
+                            member,
+                            content_id,
+                            e
+                        );
                     }
-                }
+                },
                 Ok(_) => {
                     // Member returned no operations; try the next one.
                 }
@@ -2706,7 +2704,10 @@ mod tests {
 
         assert!(result.is_err());
         assert!(
-            result.unwrap_err().to_string().contains("Content not found"),
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Content not found"),
             "relayed request to a non-member must not re-relay"
         );
     }
@@ -2747,7 +2748,10 @@ mod tests {
         );
 
         let result = service.ensure_content_local("content-1").await;
-        assert!(result.is_ok(), "expected ops pull to succeed, got {result:?}");
+        assert!(
+            result.is_ok(),
+            "expected ops pull to succeed, got {result:?}"
+        );
     }
 
     #[tokio::test]

--- a/monas-state-node/src/presentation/http_api.rs
+++ b/monas-state-node/src/presentation/http_api.rs
@@ -684,6 +684,12 @@ async fn get_content_data(
     headers: HeaderMap,
     Query(query): Query<VersionQuery>,
 ) -> impl IntoResponse {
+    // Bug #93: if this node holds no local state for the content (it is neither
+    // the creator nor a member), pull it from a member first so the read below
+    // and the access-policy check both see the real data. Best-effort: on
+    // failure we fall through to the normal local read (which 404s as before).
+    let _ = state.ensure_content_local(&content_id).await;
+
     if let Err(response) = verify_read_access(&state, &headers, &content_id).await {
         return response;
     }
@@ -735,6 +741,9 @@ async fn get_content_history(
     Path(content_id): Path<String>,
     headers: HeaderMap,
 ) -> impl IntoResponse {
+    // Bug #93: pull content from a member if we hold none locally (best-effort).
+    let _ = state.ensure_content_local(&content_id).await;
+
     if let Err(response) = verify_read_access(&state, &headers, &content_id).await {
         return response;
     }
@@ -768,6 +777,9 @@ async fn get_content_version(
     Path((content_id, version)): Path<(String, String)>,
     headers: HeaderMap,
 ) -> impl IntoResponse {
+    // Bug #93: pull content from a member if we hold none locally (best-effort).
+    let _ = state.ensure_content_local(&content_id).await;
+
     if let Err(response) = verify_read_access(&state, &headers, &content_id).await {
         return response;
     }


### PR DESCRIPTION
## 背景 / Problem

relay / sync / read がすべて **ローカルに保存済みの `ContentNetwork` member レコード**にのみ依存していた(bug #93 = `Monas-project/monas-issues#93`、旧 `monas#51`)。

そのコンテンツのレコードを持たないノード(= creator でも member でもないノード)がリクエストを受けると `ContentNotFound`(404)を返す。結果として、**1 端末・1 gateway 構成で gateway の接続先 state node を A→B に切り替えると、A で作ったコンテンツを B 経由で update / delete / 履歴表示できない**(「どのノードに繋いでも OK」が成立しない)。

PR #48 で DialFailure(408)は解消済みなので、残るデモ阻害要因はこの #93。

## 変更 / What

create_content と同じ配置ロジック(`compute_dht_key` + `min_replication_factor`)で、ローカルにレコードが無いときは **DHT から member を発見**する。

- **`resolve_members`**: ローカルレコード優先、無ければ `find_closest_peers` で発見(自ノード除外)。
- **write 系(update / delete / invalidate_tokens)**: レコード無し=即 404 をやめ、発見した member へ `relay_with_failover` で relay。
- **1-hop ガード**: relay 受信専用の公開エントリ `*_via_relay` を新設し、relay 経由で来たリクエストは再 relay しない(循環防止)。**ワイヤ形式は無変更**(node.rs の relay 受信ハンドラが「relay 経由」を知る唯一の地点なのでフラグをワイヤに載せる必要がない)→ **後方互換完全・同時デプロイ不要**。
- **read 系(data / history / version)**: `ensure_content_local` を追加。ローカル miss 時に member からオペを取得してローカル適用してから読む。適用したオペにアクセスポリシーが含まれるため `verify_read_access` も正しく機能する。verify-integrity / latest-version は SDK が history+data から計算するので連動して直る。

## テスト / Tests

- 新規 unit 6本: discovery relay(update/delete)、1-hop ガード、`NoAvailableMembers`、`ensure_content_local` の pull/miss。
- 既存の挙動依存テスト1本を新仕様に更新。
- `cargo test -p monas-state-node` **335 件 green**、clippy 警告ゼロ。既存 4-node e2e smoke も無傷。

## 手動検証 / Manual verification

1. `monas-state-node/scripts/start-4-nodes.sh`(:8080-:8083, `MIN_REPLICATION_FACTOR=3`)。
2. gateway を `MONAS_STATE_NODE_URL=http://127.0.0.1:8080` で起動 → example-ui で 1 ファイル作成。
3. gateway を `MONAS_STATE_NODE_URL=http://127.0.0.1:8081` に変えて再起動 → 同ファイルを update / delete / 履歴表示 → **404 にならず成功**。

## スコープ外 / Out of scope

- get content / share は SDK ローカル完結なのでノード切替で壊れず、本 PR の対象外。
- 複数端末・他人との共有(wrapped CEK の state node 保存)は別件(`monas-issues#92` 周辺)。

## 留保 / Caveats

- **SECURITY**: read relay は既存の**無認可** `fetch_operations` RPC を流用しており、非 member が任意コンテンツのオペを取得できる露出がある。単一ユーザーのデモでは許容。本番化では read 専用 RPC + member 側認可へ格上げが必要(#93 フォローアップ)。コードに TODO 記載済み。
- `resolve_members` の DHT 発見は create 時選定と「近い」が厳密一致ではない(トポロジ安定前提)。
- 実 DHT を使う relay e2e は DHT タイミング依存でフレーキー、かつ既存 e2e が `run()` を起こさない設計のため未追加。決定的な unit テスト + 上記手動検証でカバー。

---

Refs: `Monas-project/monas-issues#93`
(クロスリポジトリのため GitHub の自動クローズキーワードは効かない。マージ時に monas-issues#93 を手動クローズする。)

🤖 Generated with [Claude Code](https://claude.com/claude-code)