### PR TITLE
fix(state-node): relay/write routing — DHT member discovery (#93) + genesis-presence writes + redundancy self-capacity fix

### DIFF
--- a/monas-state-node/src/application_service/node.rs
+++ b/monas-state-node/src/application_service/node.rs
@@ -356,7 +356,7 @@ impl StateNode {
                                 } => {
                                     let token = AuthToken::new(auth_token);
                                     service_for_relay
-                                        .update_content(
+                                        .update_content_via_relay(
                                             &content_id,
                                             &data,
                                             Some(&token),
@@ -374,7 +374,7 @@ impl StateNode {
                                 } => {
                                     let token = AuthToken::new(auth_token);
                                     service_for_relay
-                                        .delete_content(
+                                        .delete_content_via_relay(
                                             &content_id,
                                             Some(&token),
                                             Some(&request_signature),
@@ -391,7 +391,7 @@ impl StateNode {
                                 } => {
                                     let token = AuthToken::new(auth_token);
                                     service_for_relay
-                                        .invalidate_tokens(
+                                        .invalidate_tokens_via_relay(
                                             &content_id,
                                             &token,
                                             Some(&request_signature),

--- a/monas-state-node/src/application_service/state_node_service.rs
+++ b/monas-state-node/src/application_service/state_node_service.rs
@@ -345,18 +345,27 @@ where
     /// Decide whether a write (update/delete/invalidate) should be committed
     /// locally or relayed to another node.
     ///
-    /// The deciding factor is whether **this node holds the CRDT genesis** for
-    /// the content, not whether it appears in the ContentNetwork member set.
+    /// The deciding factor is whether **this node holds the CRDT genesis node**
+    /// for the content, not whether it appears in the ContentNetwork member set.
     /// Local commits go through `commit_operation`, which fails with "Genesis
-    /// not found" when the genesis is absent. Two cases legitimately lack the
-    /// genesis and must relay instead: the node that first received
-    /// `create_content` (a non-member relay that intentionally never persisted
-    /// the genesis), and a freshly added member that has not yet synced the
-    /// genesis. Both are transient/structural states keyed purely on local CRDT
-    /// presence — no notion of "who created the content" is stored or
-    /// consulted, so membership and creator identity stay private.
+    /// not found" when the genesis node is absent. Two cases legitimately lack
+    /// it and must relay instead: the node that first received `create_content`
+    /// (a non-member relay that intentionally never persisted the genesis), and
+    /// a freshly added member that has not yet synced the genesis. Both are
+    /// transient/structural states keyed purely on local CRDT presence — no
+    /// notion of "who created the content" is stored or consulted, so membership
+    /// and creator identity stay private.
+    ///
+    /// We check `has_genesis` (the genesis node is in our DAG), not `exists`
+    /// (any version in the series): a partial sync can leave us with later
+    /// versions but no genesis, where `exists` is `true` yet a local commit
+    /// still fails with "Genesis not found". `has_genesis` matches what a local
+    /// commit can actually do.
     async fn can_commit_locally(&self, genesis_cid: &str) -> bool {
-        self.crdt_repo.exists(genesis_cid).await.unwrap_or(false)
+        self.crdt_repo
+            .has_genesis(genesis_cid)
+            .await
+            .unwrap_or(false)
     }
 
     /// Classify a relay error message into the appropriate StateNodeError.
@@ -1541,11 +1550,22 @@ where
             return Ok(());
         }
 
-        // 2. Query capacity of all member nodes
+        // 2. Query capacity of the *other* member nodes. We must not query our
+        //    own capacity over the network: libp2p does not deliver a node's
+        //    request to itself, so the self-query times out and the result is
+        //    missing — which `unwrap_or(0)` below would then read as 0 bytes,
+        //    wrongly flagging us as low-capacity and triggering spurious member
+        //    additions. We are running and serving this very check, so we count
+        //    ourselves as healthy directly.
         let member_list: Vec<String> = network.member_nodes_as_strings();
+        let peers_to_query: Vec<String> = member_list
+            .iter()
+            .filter(|id| *id != &self.local_node_id)
+            .cloned()
+            .collect();
         let capacities = self
             .peer_network
-            .query_node_capacity_batch(&member_list)
+            .query_node_capacity_batch(&peers_to_query)
             .await
             .map_err(|e| {
                 StateNodeError::NetworkError(NetworkError::ConnectionFailed(e.to_string()))
@@ -1556,6 +1576,12 @@ where
         let mut healthy_count = 0usize;
 
         for node_id in &member_list {
+            // We are healthy from our own perspective (see above) — never flag
+            // ourselves as low-capacity based on a network query we can't make.
+            if node_id == &self.local_node_id {
+                healthy_count += 1;
+                continue;
+            }
             let available = capacities.get(node_id).cloned().unwrap_or(0);
             if available < self.capacity_threshold_bytes {
                 low_capacity_nodes.push(node_id.clone());

--- a/monas-state-node/src/application_service/state_node_service.rs
+++ b/monas-state-node/src/application_service/state_node_service.rs
@@ -342,6 +342,23 @@ where
         self.peer_network.listen_addrs().await
     }
 
+    /// Decide whether a write (update/delete/invalidate) should be committed
+    /// locally or relayed to another node.
+    ///
+    /// The deciding factor is whether **this node holds the CRDT genesis** for
+    /// the content, not whether it appears in the ContentNetwork member set.
+    /// Local commits go through `commit_operation`, which fails with "Genesis
+    /// not found" when the genesis is absent. Two cases legitimately lack the
+    /// genesis and must relay instead: the node that first received
+    /// `create_content` (a non-member relay that intentionally never persisted
+    /// the genesis), and a freshly added member that has not yet synced the
+    /// genesis. Both are transient/structural states keyed purely on local CRDT
+    /// presence — no notion of "who created the content" is stored or
+    /// consulted, so membership and creator identity stay private.
+    async fn can_commit_locally(&self, genesis_cid: &str) -> bool {
+        self.crdt_repo.exists(genesis_cid).await.unwrap_or(false)
+    }
+
     /// Classify a relay error message into the appropriate StateNodeError.
     ///
     /// When a member node returns an error during relay, the error message is
@@ -797,24 +814,15 @@ where
             StateNodeError::AuthenticationFailed("Request signature is required".to_string())
         })?;
 
-        // 1. Look up the content network. Unlike before, a missing record is
-        //    not an immediate 404: a non-member node can still relay to the
-        //    real members discovered via the DHT (bug #93).
+        // 1. A missing local record is not an immediate 404: a node that does
+        //    not hold the content can still relay to the real members
+        //    discovered via the DHT (bug #93).
         let content_id_vo = ContentId::new(content_id.to_string())?;
-        let network = self
-            .content_repo
-            .read()
-            .await
-            .get_content_network(content_id)
-            .await
-            .map_err(|e| StateNodeError::StorageError(e.to_string()))?;
 
-        // 2. Check if local node is a member
-        let is_member = network
-            .as_ref()
-            .is_some_and(|n| n.has_member_str(&self.local_node_id));
-        if is_member {
-            // Local delete path: we are a member node
+        // 2. Decide local commit vs relay by genesis presence (not membership):
+        //    only a node that actually holds the CRDT genesis can delete locally.
+        if self.can_commit_locally(content_id).await {
+            // Local delete path: we hold the genesis
             // Authenticate and authorize locally (we have the up-to-date access policy)
             let auth_service = self.auth_service.as_ref().ok_or_else(|| {
                 StateNodeError::InvalidConfiguration("Authentication not configured".to_string())
@@ -976,24 +984,15 @@ where
             StateNodeError::AuthenticationFailed("Request signature is required".to_string())
         })?;
 
-        // 1. Look up the content network. A missing record is not an immediate
-        //    404: a non-member node can still relay to the real members
+        // 1. A missing local record is not an immediate 404: a node that does
+        //    not hold the content can still relay to the real members
         //    discovered via the DHT (bug #93).
         let content_id_vo = ContentId::new(content_id.to_string())?;
-        let network = self
-            .content_repo
-            .read()
-            .await
-            .get_content_network(content_id)
-            .await
-            .map_err(|e| StateNodeError::StorageError(e.to_string()))?;
 
-        // 2. Check if local node is a member
-        let is_member = network
-            .as_ref()
-            .is_some_and(|n| n.has_member_str(&self.local_node_id));
-        if is_member {
-            // Local update path: we are a member node
+        // 2. Decide local commit vs relay by genesis presence (not membership):
+        //    only a node that actually holds the CRDT genesis can update locally.
+        if self.can_commit_locally(content_id).await {
+            // Local update path: we hold the genesis
             // Authenticate and authorize locally (we have the up-to-date access policy)
             let auth_service = self.auth_service.as_ref().ok_or_else(|| {
                 StateNodeError::InvalidConfiguration("Authentication not configured".to_string())
@@ -1210,12 +1209,12 @@ where
             .await
             .map_err(|e| StateNodeError::StorageError(e.to_string()))?;
 
-        let is_member = network
-            .as_ref()
-            .is_some_and(|n| n.has_member_str(&self.local_node_id));
-        if is_member {
-            let network = network.expect("is_member implies Some");
-            // Local path: we are a member node
+        // Decide local commit vs relay by genesis presence (not membership):
+        // only a node that actually holds the CRDT genesis can invalidate
+        // locally. A member that has not yet synced the genesis, or the
+        // create-time relay node, lacks it and must relay instead.
+        if self.can_commit_locally(content_id).await {
+            // Local path: we hold the genesis
             // 4. Get access policy from CRDT
             let mut policy = self
                 .crdt_repo
@@ -1272,8 +1271,15 @@ where
                         StateNodeError::CrdtError(CrdtError::StorageError(e.to_string()))
                     })?;
 
+                // Push to the members we know about. When we hold the genesis
+                // but have no local ContentNetwork record (a rare transient
+                // state under genesis-based routing), there is no member list to
+                // push to here; gossip/sync still propagates the change.
+                let members = network
+                    .as_ref()
+                    .map(|n| n.member_nodes_as_strings())
+                    .unwrap_or_default();
                 if !operations.is_empty() {
-                    let members = network.member_nodes_as_strings();
                     for member_id in &members {
                         if member_id == &self.local_node_id {
                             continue;
@@ -3019,6 +3025,137 @@ mod tests {
             .await
             .unwrap();
         assert!(network.is_none());
+    }
+
+    // Writes are routed by genesis presence, not membership, so a node may be a
+    // member yet still relay (until it has synced the genesis). The
+    // ContentNetworkManagerAdded handler therefore accepts promotion of a
+    // former relay node into the member set instead of refusing it.
+    #[tokio::test]
+    async fn test_content_network_manager_added_promotes_former_relay_node() {
+        // Seed a local record where node-1 (us) is currently a non-member relay:
+        // the network it remembers contains only node-2 and node-3.
+        let node_registry = MockNodeRegistry::new();
+        let content_repo = Arc::new(RwLock::new(
+            MockContentNetworkRepository::new()
+                .with_network(create_test_network("content-1", vec!["node-2", "node-3"])),
+        ));
+        let peer_network = Arc::new(MockPeerNetwork::new().with_local_peer_id("node-1"));
+        let event_publisher = MockEventPublisher::new();
+        let crdt_repo = Arc::new(MockContentRepository::new());
+
+        let service: TestService = StateNodeService::new(
+            node_registry,
+            content_repo,
+            peer_network,
+            event_publisher,
+            crdt_repo,
+            "node-1".to_string(),
+        )
+        .with_authentication_service(TestAuthService)
+        .with_authorization_service(AllowAllAuthorizationService);
+
+        // A redundancy check on another node added us (node-1) to the member set.
+        let event = Event::ContentNetworkManagerAdded {
+            content_id: "content-1".to_string(),
+            added_node_id: "node-1".to_string(),
+            member_nodes: vec![
+                "node-1".to_string(),
+                "node-2".to_string(),
+                "node-3".to_string(),
+            ],
+            timestamp: 12345,
+        };
+
+        let outcome = service.handle_sync_event(&event, None).await.unwrap();
+        // Promotion is accepted (not Ignored): the former relay becomes a member.
+        assert_eq!(
+            outcome,
+            ApplyOutcome::NeedsSync {
+                content_id: "content-1".to_string(),
+            }
+        );
+
+        // The local record now lists node-1 as a member.
+        let network = service
+            .get_content_network_for_test("content-1")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(network.has_member_str("node-1"));
+    }
+
+    // A node that is a member but does not yet hold the genesis must relay its
+    // writes (and never to itself), because local commit would fail with
+    // "Genesis not found". This is the discriminator for genesis-based routing.
+    #[tokio::test]
+    async fn test_update_relays_when_member_but_genesis_absent() {
+        let node_registry = MockNodeRegistry::new();
+        // node-1 (us) IS listed as a member alongside node-2.
+        let content_repo = Arc::new(RwLock::new(
+            MockContentNetworkRepository::new()
+                .with_network(create_test_network("content-1", vec!["node-1", "node-2"])),
+        ));
+        // Keep a handle to the peer network so we can assert the relay path was
+        // actually taken (not just that the call returned Ok — the mock CRDT
+        // repo would happily "commit" locally without a genesis, so observing
+        // the relay invocation is the only way to distinguish the two paths).
+        let peer_network = Arc::new(MockPeerNetwork::new().with_local_peer_id("node-1"));
+        let event_publisher = MockEventPublisher::new();
+        // CRDT repo is empty: we hold no genesis for content-1, so a local
+        // commit would (in production) fail with "Genesis not found".
+        let crdt_repo = Arc::new(MockContentRepository::new());
+
+        let service: TestService = StateNodeService::new(
+            node_registry,
+            content_repo,
+            peer_network.clone(),
+            event_publisher,
+            crdt_repo,
+            "node-1".to_string(),
+        )
+        .with_authentication_service(TestAuthService)
+        .with_authorization_service(AllowAllAuthorizationService);
+
+        // Despite being a member, the write must relay (and succeed) because we
+        // lack the genesis — not commit locally.
+        let result = service
+            .update_content(
+                "content-1",
+                b"new data",
+                Some(&test_token()),
+                Some(&test_request_signature()),
+                None,
+            )
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "member-without-genesis must relay successfully, got: {:?}",
+            result.err()
+        );
+        // The discriminating assertion: the relay path was taken exactly because
+        // the genesis was absent. If routing reverted to membership-based, this
+        // would be 0 (the node would have committed locally).
+        assert_eq!(
+            *peer_network.relay_update_calls.lock().await,
+            1,
+            "expected the update to be relayed once due to missing genesis",
+        );
+        // And it must never relay to itself: node-1 is in its own member set
+        // (it was promoted) but holds no genesis, so the only valid relay
+        // target is node-2. Relaying to self would waste a failover attempt.
+        let targets = peer_network.relay_update_peers.lock().await.clone();
+        assert!(
+            !targets.contains(&"node-1".to_string()),
+            "must not relay to self (node-1); relayed to: {:?}",
+            targets
+        );
+        assert_eq!(
+            targets,
+            vec!["node-2".to_string()],
+            "relay must target the other member only",
+        );
     }
 
     #[tokio::test]

--- a/monas-state-node/src/application_service/state_node_service.rs
+++ b/monas-state-node/src/application_service/state_node_service.rs
@@ -407,6 +407,121 @@ where
         Err(StateNodeError::NoAvailableMembers)
     }
 
+    /// Resolve the member nodes that own a content, for relay/sync purposes.
+    ///
+    /// If we hold a local `ContentNetwork` record, return its member set
+    /// (current behaviour). If we do not — e.g. a client sent a request to a
+    /// node that was neither the creator nor a member — fall back to DHT
+    /// discovery using the same key function and replication factor that
+    /// `create_content` used to place the content (`compute_dht_key` +
+    /// `min_replication_factor`). This lets any node relay a request to the
+    /// real members instead of returning `ContentNotFound` (bug #93).
+    ///
+    /// The local node is always excluded from the result. Returns
+    /// `NoAvailableMembers` if no candidate remains.
+    async fn resolve_members(&self, content_id: &str) -> Result<Vec<String>, StateNodeError> {
+        let local_record = self
+            .content_repo
+            .read()
+            .await
+            .get_content_network(content_id)
+            .await
+            .map_err(|e| StateNodeError::StorageError(e.to_string()))?;
+
+        let mut members: Vec<String> = match local_record {
+            Some(network) => network.member_nodes_as_strings(),
+            None => {
+                // No local record: discover the members via the DHT. Request
+                // `k + 1` candidates so that excluding ourselves still leaves
+                // up to `k`, mirroring create_content's placement.
+                let key = compute_dht_key(content_id);
+                self.peer_network
+                    .find_closest_peers(key, self.min_replication_factor + 1)
+                    .await
+                    .map_err(|e| {
+                        StateNodeError::NetworkError(NetworkError::ConnectionFailed(e.to_string()))
+                    })?
+            }
+        };
+
+        members.retain(|peer| peer != &self.local_node_id);
+        if members.is_empty() {
+            return Err(StateNodeError::NoAvailableMembers);
+        }
+        Ok(members)
+    }
+
+    /// Ensure the content's CRDT state is available locally, fetching it from
+    /// member nodes if necessary (bug #93, read side).
+    ///
+    /// Read endpoints (data / history / version) read straight from the local
+    /// `crdt_repo`. A node that holds no local state for a content — e.g. a
+    /// client pointed its gateway at a node that is neither the creator nor a
+    /// member — would otherwise 404. This pulls the operations from a member
+    /// (discovered via `resolve_members`) and applies them locally so the
+    /// existing read path works unchanged. Applying the operations also brings
+    /// in the access policy, so the subsequent `verify_read_access` check is
+    /// evaluated against the real policy rather than an empty one.
+    ///
+    /// No-op when we already have local history. Returns `ContentNotFound` if
+    /// no member could supply the operations.
+    ///
+    /// SECURITY NOTE: this reuses the unauthenticated `fetch_operations` RPC,
+    /// so a non-member can pull any content's operations. Acceptable for the
+    /// single-user demo; a hardened version should add a read-relay RPC with
+    /// member-side authorization. Tracked in bug #93 follow-up.
+    pub async fn ensure_content_local(&self, content_id: &str) -> Result<(), StateNodeError> {
+        // Fast path: we already hold local history for this content.
+        let has_local = self
+            .crdt_repo
+            .get_history(content_id)
+            .await
+            .map(|h| !h.is_empty())
+            .unwrap_or(false);
+        if has_local {
+            return Ok(());
+        }
+
+        // Discover the members (local record, or DHT fallback) and pull ops.
+        let members = self.resolve_members(content_id).await?;
+        let content_id_vo = ContentId::new(content_id.to_string())?;
+
+        for member in &members {
+            match self
+                .peer_network
+                .fetch_operations(member, content_id, None)
+                .await
+            {
+                Ok(ops) if !ops.is_empty() => {
+                    match self.crdt_repo.apply_operations(&ops).await {
+                        Ok(_) => return Ok(()),
+                        Err(e) => {
+                            tracing::warn!(
+                                "ensure_content_local: failed to apply ops from {} for {}: {}",
+                                member,
+                                content_id,
+                                e
+                            );
+                        }
+                    }
+                }
+                Ok(_) => {
+                    // Member returned no operations; try the next one.
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "ensure_content_local: failed to fetch ops from {} for {}: {}",
+                        member,
+                        content_id,
+                        e
+                    );
+                }
+            }
+        }
+
+        Err(StateNodeError::ContentNotFound(content_id_vo))
+    }
+
     /// Register a new node.
     ///
     /// This publishes the NodeCreated event both locally and to the network.
@@ -651,6 +766,32 @@ where
         request_signature: Option<&[u8]>,
         timestamp: Option<u64>,
     ) -> Result<Event, StateNodeError> {
+        self.delete_content_inner(content_id, token, request_signature, timestamp, false)
+            .await
+    }
+
+    /// Entry point for `delete` requests that arrived via relay from another
+    /// node. Identical to [`delete_content`] except that it will not relay
+    /// again — enforcing a 1-hop relay limit to prevent cycles (bug #93).
+    pub async fn delete_content_via_relay(
+        &self,
+        content_id: &str,
+        token: Option<&AuthToken>,
+        request_signature: Option<&[u8]>,
+        timestamp: Option<u64>,
+    ) -> Result<Event, StateNodeError> {
+        self.delete_content_inner(content_id, token, request_signature, timestamp, true)
+            .await
+    }
+
+    async fn delete_content_inner(
+        &self,
+        content_id: &str,
+        token: Option<&AuthToken>,
+        request_signature: Option<&[u8]>,
+        timestamp: Option<u64>,
+        from_relay: bool,
+    ) -> Result<Event, StateNodeError> {
         let token = token.ok_or_else(|| {
             StateNodeError::AuthenticationFailed("Authentication token is required".to_string())
         })?;
@@ -658,7 +799,9 @@ where
             StateNodeError::AuthenticationFailed("Request signature is required".to_string())
         })?;
 
-        // 1. Verify content network exists
+        // 1. Look up the content network. Unlike before, a missing record is
+        //    not an immediate 404: a non-member node can still relay to the
+        //    real members discovered via the DHT (bug #93).
         let content_id_vo = ContentId::new(content_id.to_string())?;
         let network = self
             .content_repo
@@ -666,11 +809,13 @@ where
             .await
             .get_content_network(content_id)
             .await
-            .map_err(|e| StateNodeError::StorageError(e.to_string()))?
-            .ok_or_else(|| StateNodeError::ContentNotFound(content_id_vo.clone()))?;
+            .map_err(|e| StateNodeError::StorageError(e.to_string()))?;
 
         // 2. Check if local node is a member
-        if network.has_member_str(&self.local_node_id) {
+        let is_member = network
+            .as_ref()
+            .is_some_and(|n| n.has_member_str(&self.local_node_id));
+        if is_member {
             // Local delete path: we are a member node
             // Authenticate and authorize locally (we have the up-to-date access policy)
             let auth_service = self.auth_service.as_ref().ok_or_else(|| {
@@ -743,11 +888,19 @@ where
 
             Ok(event)
         } else {
-            // Relay path: we are not a member, relay to a member node with failover.
-            let members = network.member_nodes_as_strings();
-            if members.is_empty() {
-                return Err(StateNodeError::NoAvailableMembers);
+            // Relay path: we are not a member.
+            //
+            // 1-hop limit: if this request itself arrived via relay, do not
+            // relay again — the previous hop already resolved members, so a
+            // non-member receiver here means the chosen member was wrong.
+            // Refusing to re-relay prevents relay cycles (bug #93).
+            if from_relay {
+                return Err(StateNodeError::ContentNotFound(content_id_vo.clone()));
             }
+
+            // Resolve members from our local record, or via DHT discovery when
+            // we hold no record (bug #93), then relay with failover.
+            let members = self.resolve_members(content_id).await?;
 
             let token_str = token.as_str().to_string();
             let content_id_owned = content_id.to_string();
@@ -789,6 +942,35 @@ where
         request_signature: Option<&[u8]>,
         timestamp: Option<u64>,
     ) -> Result<Event, StateNodeError> {
+        self.update_content_inner(content_id, data, token, request_signature, timestamp, false)
+            .await
+    }
+
+    /// Entry point for `update` requests that arrived via relay from another
+    /// node. Identical to [`update_content`] except that it will not relay
+    /// again — enforcing a 1-hop relay limit to prevent cycles (bug #93).
+    pub async fn update_content_via_relay(
+        &self,
+        content_id: &str,
+        data: &[u8],
+        token: Option<&AuthToken>,
+        request_signature: Option<&[u8]>,
+        timestamp: Option<u64>,
+    ) -> Result<Event, StateNodeError> {
+        self.update_content_inner(content_id, data, token, request_signature, timestamp, true)
+            .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn update_content_inner(
+        &self,
+        content_id: &str,
+        data: &[u8],
+        token: Option<&AuthToken>,
+        request_signature: Option<&[u8]>,
+        timestamp: Option<u64>,
+        from_relay: bool,
+    ) -> Result<Event, StateNodeError> {
         let token = token.ok_or_else(|| {
             StateNodeError::AuthenticationFailed("Authentication token is required".to_string())
         })?;
@@ -796,7 +978,9 @@ where
             StateNodeError::AuthenticationFailed("Request signature is required".to_string())
         })?;
 
-        // 1. Verify content network exists
+        // 1. Look up the content network. A missing record is not an immediate
+        //    404: a non-member node can still relay to the real members
+        //    discovered via the DHT (bug #93).
         let content_id_vo = ContentId::new(content_id.to_string())?;
         let network = self
             .content_repo
@@ -804,11 +988,13 @@ where
             .await
             .get_content_network(content_id)
             .await
-            .map_err(|e| StateNodeError::StorageError(e.to_string()))?
-            .ok_or_else(|| StateNodeError::ContentNotFound(content_id_vo.clone()))?;
+            .map_err(|e| StateNodeError::StorageError(e.to_string()))?;
 
         // 2. Check if local node is a member
-        if network.has_member_str(&self.local_node_id) {
+        let is_member = network
+            .as_ref()
+            .is_some_and(|n| n.has_member_str(&self.local_node_id));
+        if is_member {
             // Local update path: we are a member node
             // Authenticate and authorize locally (we have the up-to-date access policy)
             let auth_service = self.auth_service.as_ref().ok_or_else(|| {
@@ -888,11 +1074,16 @@ where
 
             Ok(event)
         } else {
-            // Relay path: we are not a member, relay to a member node with failover.
-            let members = network.member_nodes_as_strings();
-            if members.is_empty() {
-                return Err(StateNodeError::NoAvailableMembers);
+            // Relay path: we are not a member.
+            //
+            // 1-hop limit: a relayed request must not be relayed again (bug #93).
+            if from_relay {
+                return Err(StateNodeError::ContentNotFound(content_id_vo.clone()));
             }
+
+            // Resolve members from our local record, or via DHT discovery when
+            // we hold no record (bug #93), then relay with failover.
+            let members = self.resolve_members(content_id).await?;
 
             let token_str = token.as_str().to_string();
             let content_id_owned = content_id.to_string();
@@ -949,6 +1140,32 @@ where
         request_signature: Option<&[u8]>,
         timestamp: Option<u64>,
     ) -> Result<u64, StateNodeError> {
+        self.invalidate_tokens_inner(content_id, token, request_signature, timestamp, false)
+            .await
+    }
+
+    /// Entry point for `invalidate_tokens` requests that arrived via relay from
+    /// another node. Identical to [`invalidate_tokens`] except that it will not
+    /// relay again — enforcing a 1-hop relay limit to prevent cycles (bug #93).
+    pub async fn invalidate_tokens_via_relay(
+        &self,
+        content_id: &str,
+        token: &AuthToken,
+        request_signature: Option<&[u8]>,
+        timestamp: Option<u64>,
+    ) -> Result<u64, StateNodeError> {
+        self.invalidate_tokens_inner(content_id, token, request_signature, timestamp, true)
+            .await
+    }
+
+    async fn invalidate_tokens_inner(
+        &self,
+        content_id: &str,
+        token: &AuthToken,
+        request_signature: Option<&[u8]>,
+        timestamp: Option<u64>,
+        from_relay: bool,
+    ) -> Result<u64, StateNodeError> {
         // 1. Ensure auth services are configured
         let auth_service = self.auth_service.as_ref().ok_or_else(|| {
             StateNodeError::InvalidConfiguration("Authentication not configured".to_string())
@@ -983,7 +1200,9 @@ where
         )
         .await?;
 
-        // 3. Check if this node is a member
+        // 3. Check if this node is a member. A missing record is not an
+        //    immediate 404: a non-member node can still relay to the real
+        //    members discovered via the DHT (bug #93).
         let content_id_vo = ContentId::new(content_id.to_string())?;
         let network = self
             .content_repo
@@ -991,10 +1210,13 @@ where
             .await
             .get_content_network(content_id)
             .await
-            .map_err(|e| StateNodeError::StorageError(e.to_string()))?
-            .ok_or_else(|| StateNodeError::ContentNotFound(content_id_vo.clone()))?;
+            .map_err(|e| StateNodeError::StorageError(e.to_string()))?;
 
-        if network.has_member_str(&self.local_node_id) {
+        let is_member = network
+            .as_ref()
+            .is_some_and(|n| n.has_member_str(&self.local_node_id));
+        if is_member {
+            let network = network.expect("is_member implies Some");
             // Local path: we are a member node
             // 4. Get access policy from CRDT
             let mut policy = self
@@ -1074,11 +1296,16 @@ where
 
             Ok(new_min)
         } else {
-            // Relay path: we are not a member, relay to a member node
-            let members = network.member_nodes_as_strings();
-            if members.is_empty() {
-                return Err(StateNodeError::NoAvailableMembers);
+            // Relay path: we are not a member.
+            //
+            // 1-hop limit: a relayed request must not be relayed again (bug #93).
+            if from_relay {
+                return Err(StateNodeError::ContentNotFound(content_id_vo.clone()));
             }
+
+            // Resolve members from our local record, or via DHT discovery when
+            // we hold no record (bug #93), then relay with failover.
+            let members = self.resolve_members(content_id).await?;
 
             let token_str = token.as_str().to_string();
             let content_id_owned = content_id.to_string();
@@ -2366,7 +2593,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_update_content_fails_if_network_not_found() {
+    async fn test_update_content_no_record_no_discoverable_members_errors() {
+        // With bug #93 fixed, a node holding no ContentNetwork record no longer
+        // 404s immediately — it tries to discover the members via the DHT. When
+        // discovery yields no peers (default mock), it reports NoAvailableMembers
+        // rather than ContentNotFound.
         let service = create_test_service("node-1");
 
         let result = service
@@ -2383,7 +2614,152 @@ mod tests {
         assert!(result
             .unwrap_err()
             .to_string()
-            .contains("Content not found"));
+            .contains("No available member nodes"));
+    }
+
+    #[tokio::test]
+    async fn test_update_content_no_record_relays_to_discovered_members() {
+        // Bug #93: a node that holds no ContentNetwork record must still relay
+        // the update to members discovered via the DHT, instead of 404ing.
+        let service = create_service_with_peers(
+            "node-1",
+            vec!["node-2".to_string(), "node-3".to_string()],
+            HashMap::new(),
+        );
+
+        let result = service
+            .update_content(
+                "content-1",
+                b"data",
+                Some(&test_token()),
+                Some(&test_request_signature()),
+                None,
+            )
+            .await;
+
+        assert!(result.is_ok(), "expected relay success, got {result:?}");
+        match result.unwrap() {
+            Event::ContentUpdated {
+                content_id,
+                updated_node_id,
+                ..
+            } => {
+                assert_eq!(content_id, "content-1");
+                assert_eq!(updated_node_id, "node-1");
+            }
+            other => panic!("Expected ContentUpdated event, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_delete_content_no_record_relays_to_discovered_members() {
+        // Bug #93: delete must also relay to DHT-discovered members.
+        let service = create_service_with_peers(
+            "node-1",
+            vec!["node-2".to_string(), "node-3".to_string()],
+            HashMap::new(),
+        );
+
+        let result = service
+            .delete_content(
+                "content-1",
+                Some(&test_token()),
+                Some(&test_request_signature()),
+                None,
+            )
+            .await;
+
+        assert!(result.is_ok(), "expected relay success, got {result:?}");
+        match result.unwrap() {
+            Event::ContentDeleted {
+                content_id,
+                deleted_by_node_id,
+                ..
+            } => {
+                assert_eq!(content_id, "content-1");
+                assert_eq!(deleted_by_node_id, "node-1");
+            }
+            other => panic!("Expected ContentDeleted event, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_update_via_relay_does_not_re_relay_when_not_member() {
+        // Bug #93 1-hop guard: a request that arrived via relay must NOT be
+        // relayed again. A non-member receiver of a relayed update returns
+        // ContentNotFound instead of forwarding (which would risk a cycle).
+        let service = create_service_with_peers(
+            "node-1",
+            vec!["node-2".to_string(), "node-3".to_string()],
+            HashMap::new(),
+        );
+
+        let result = service
+            .update_content_via_relay(
+                "content-1",
+                b"data",
+                Some(&test_token()),
+                Some(&test_request_signature()),
+                None,
+            )
+            .await;
+
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().to_string().contains("Content not found"),
+            "relayed request to a non-member must not re-relay"
+        );
+    }
+
+    fn sample_operation(genesis_cid: &str) -> crate::port::content_repository::SerializedOperation {
+        crate::port::content_repository::SerializedOperation {
+            data: vec![0x01, 0x02],
+            genesis_cid: genesis_cid.to_string(),
+            author: "node-2".to_string(),
+            timestamp: 1,
+            node_timestamp: 1,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_ensure_content_local_pulls_from_discovered_member() {
+        // Bug #93 (read side): a node with no local state for the content must
+        // pull the operations from a DHT-discovered member and apply them
+        // locally so the read endpoints work instead of 404ing.
+        let node_registry = MockNodeRegistry::new();
+        let content_repo = Arc::new(RwLock::new(MockContentNetworkRepository::new()));
+        let peer_network = Arc::new(
+            MockPeerNetwork::new()
+                .with_local_peer_id("node-1")
+                .with_closest_peers(vec!["node-2".to_string()])
+                .with_fetched_operations(vec![sample_operation("content-1")]),
+        );
+        let event_publisher = MockEventPublisher::new();
+        let crdt_repo = Arc::new(MockContentRepository::new());
+
+        let service: TestService = StateNodeService::new(
+            node_registry,
+            content_repo,
+            peer_network,
+            event_publisher,
+            crdt_repo,
+            "node-1".to_string(),
+        );
+
+        let result = service.ensure_content_local("content-1").await;
+        assert!(result.is_ok(), "expected ops pull to succeed, got {result:?}");
+    }
+
+    #[tokio::test]
+    async fn test_ensure_content_local_errors_when_no_member_has_data() {
+        // No discoverable members → cannot pull → ContentNotFound.
+        let service = create_test_service("node-1");
+        let result = service.ensure_content_local("content-1").await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("No available member nodes"));
     }
 
     #[tokio::test]

--- a/monas-state-node/src/application_service/state_node_service.rs
+++ b/monas-state-node/src/application_service/state_node_service.rs
@@ -492,19 +492,17 @@ where
                 .fetch_operations(member, content_id, None)
                 .await
             {
-                Ok(ops) if !ops.is_empty() => {
-                    match self.crdt_repo.apply_operations(&ops).await {
-                        Ok(_) => return Ok(()),
-                        Err(e) => {
-                            tracing::warn!(
-                                "ensure_content_local: failed to apply ops from {} for {}: {}",
-                                member,
-                                content_id,
-                                e
-                            );
-                        }
+                Ok(ops) if !ops.is_empty() => match self.crdt_repo.apply_operations(&ops).await {
+                    Ok(_) => return Ok(()),
+                    Err(e) => {
+                        tracing::warn!(
+                            "ensure_content_local: failed to apply ops from {} for {}: {}",
+                            member,
+                            content_id,
+                            e
+                        );
                     }
-                }
+                },
                 Ok(_) => {
                     // Member returned no operations; try the next one.
                 }
@@ -2706,7 +2704,10 @@ mod tests {
 
         assert!(result.is_err());
         assert!(
-            result.unwrap_err().to_string().contains("Content not found"),
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Content not found"),
             "relayed request to a non-member must not re-relay"
         );
     }
@@ -2747,7 +2748,10 @@ mod tests {
         );
 
         let result = service.ensure_content_local("content-1").await;
-        assert!(result.is_ok(), "expected ops pull to succeed, got {result:?}");
+        assert!(
+            result.is_ok(),
+            "expected ops pull to succeed, got {result:?}"
+        );
     }
 
     #[tokio::test]

--- a/monas-state-node/src/infrastructure/auth/ucan_adapter.rs
+++ b/monas-state-node/src/infrastructure/auth/ucan_adapter.rs
@@ -489,6 +489,9 @@ mod tests {
         async fn exists(&self, _genesis_cid: &str) -> Result<bool> {
             unimplemented!()
         }
+        async fn has_genesis(&self, _genesis_cid: &str) -> Result<bool> {
+            unimplemented!()
+        }
         async fn list_contents(&self) -> Result<Vec<String>> {
             unimplemented!()
         }

--- a/monas-state-node/src/infrastructure/crdt_repository.rs
+++ b/monas-state-node/src/infrastructure/crdt_repository.rs
@@ -451,6 +451,20 @@ impl ContentRepository for CrslCrdtRepository {
         Ok(repo.latest(&genesis).is_some())
     }
 
+    async fn has_genesis(&self, genesis_cid: &str) -> Result<bool> {
+        let genesis = match Self::parse_cid(genesis_cid) {
+            Ok(cid) => cid,
+            Err(_) => return Ok(false),
+        };
+
+        let repo = self.repo.lock();
+
+        // The genesis CID *is* a node CID, so look it up directly. Unlike
+        // `latest`, this is only true when the genesis node itself is present —
+        // not when we hold only later versions from a partial sync.
+        Ok(matches!(repo.dag.get_node(&genesis), Ok(Some(_))))
+    }
+
     async fn list_contents(&self) -> Result<Vec<String>> {
         let repo = self.repo.lock();
 

--- a/monas-state-node/src/port/content_repository.rs
+++ b/monas-state-node/src/port/content_repository.rs
@@ -159,6 +159,24 @@ pub trait ContentRepository: Send + Sync {
     /// True if the content exists.
     async fn exists(&self, genesis_cid: &str) -> Result<bool>;
 
+    /// Check whether this node actually holds the **genesis node** for the
+    /// content (not merely some version of it).
+    ///
+    /// This differs from [`exists`](Self::exists): `exists` is satisfied by any
+    /// node in the genesis series (it uses `latest`), so a node that synced
+    /// only later operations — without the genesis itself — still reports
+    /// `true`. A local write, however, must traverse the genesis node and fails
+    /// with "Genesis not found" if it is absent. Routing local-vs-relay
+    /// decisions on `has_genesis` therefore matches what a local commit can
+    /// actually do, whereas `exists` can be "true" yet still fail to commit.
+    ///
+    /// # Arguments
+    /// * `genesis_cid` - The genesis CID to check
+    ///
+    /// # Returns
+    /// True if the genesis node is present in the local DAG.
+    async fn has_genesis(&self, genesis_cid: &str) -> Result<bool>;
+
     /// List all content genesis CIDs.
     ///
     /// # Returns

--- a/monas-state-node/src/presentation/http_api.rs
+++ b/monas-state-node/src/presentation/http_api.rs
@@ -684,6 +684,12 @@ async fn get_content_data(
     headers: HeaderMap,
     Query(query): Query<VersionQuery>,
 ) -> impl IntoResponse {
+    // Bug #93: if this node holds no local state for the content (it is neither
+    // the creator nor a member), pull it from a member first so the read below
+    // and the access-policy check both see the real data. Best-effort: on
+    // failure we fall through to the normal local read (which 404s as before).
+    let _ = state.ensure_content_local(&content_id).await;
+
     if let Err(response) = verify_read_access(&state, &headers, &content_id).await {
         return response;
     }
@@ -735,6 +741,9 @@ async fn get_content_history(
     Path(content_id): Path<String>,
     headers: HeaderMap,
 ) -> impl IntoResponse {
+    // Bug #93: pull content from a member if we hold none locally (best-effort).
+    let _ = state.ensure_content_local(&content_id).await;
+
     if let Err(response) = verify_read_access(&state, &headers, &content_id).await {
         return response;
     }
@@ -768,6 +777,9 @@ async fn get_content_version(
     Path((content_id, version)): Path<(String, String)>,
     headers: HeaderMap,
 ) -> impl IntoResponse {
+    // Bug #93: pull content from a member if we hold none locally (best-effort).
+    let _ = state.ensure_content_local(&content_id).await;
+
     if let Err(response) = verify_read_access(&state, &headers, &content_id).await {
         return response;
     }

--- a/monas-state-node/src/test_utils.rs
+++ b/monas-state-node/src/test_utils.rs
@@ -37,6 +37,16 @@ pub struct MockPeerNetwork {
     pub relay_update_result: Arc<Mutex<Option<bool>>>,
     pub relay_delete_result: Arc<Mutex<Option<bool>>>,
     pub relay_invalidate_tokens_result: Arc<Mutex<Option<bool>>>,
+    /// Number of times each relay method was invoked. Lets tests assert that a
+    /// write actually took the relay path (vs committing locally).
+    pub relay_update_calls: Arc<Mutex<usize>>,
+    pub relay_delete_calls: Arc<Mutex<usize>>,
+    pub relay_invalidate_tokens_calls: Arc<Mutex<usize>>,
+    /// Target peer ids each relay method was invoked with, in order. Lets tests
+    /// assert which members a write was relayed to (e.g. never to self).
+    pub relay_update_peers: Arc<Mutex<Vec<String>>>,
+    pub relay_delete_peers: Arc<Mutex<Vec<String>>>,
+    pub relay_invalidate_tokens_peers: Arc<Mutex<Vec<String>>>,
 }
 
 impl MockPeerNetwork {
@@ -52,6 +62,12 @@ impl MockPeerNetwork {
             relay_update_result: Arc::new(Mutex::new(Some(true))),
             relay_delete_result: Arc::new(Mutex::new(Some(true))),
             relay_invalidate_tokens_result: Arc::new(Mutex::new(Some(true))),
+            relay_update_calls: Arc::new(Mutex::new(0)),
+            relay_delete_calls: Arc::new(Mutex::new(0)),
+            relay_invalidate_tokens_calls: Arc::new(Mutex::new(0)),
+            relay_update_peers: Arc::new(Mutex::new(Vec::new())),
+            relay_delete_peers: Arc::new(Mutex::new(Vec::new())),
+            relay_invalidate_tokens_peers: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
@@ -198,35 +214,50 @@ impl PeerNetwork for MockPeerNetwork {
 
     async fn relay_update_content(
         &self,
-        _peer_id: &str,
+        peer_id: &str,
         _content_id: &str,
         _data: &[u8],
         _auth_token: &str,
         _request_signature: &[u8],
         _timestamp: Option<u64>,
     ) -> Result<bool> {
+        *self.relay_update_calls.lock().await += 1;
+        self.relay_update_peers
+            .lock()
+            .await
+            .push(peer_id.to_string());
         Ok(self.relay_update_result.lock().await.unwrap_or(true))
     }
 
     async fn relay_delete_content(
         &self,
-        _peer_id: &str,
+        peer_id: &str,
         _content_id: &str,
         _auth_token: &str,
         _request_signature: &[u8],
         _timestamp: Option<u64>,
     ) -> Result<bool> {
+        *self.relay_delete_calls.lock().await += 1;
+        self.relay_delete_peers
+            .lock()
+            .await
+            .push(peer_id.to_string());
         Ok(self.relay_delete_result.lock().await.unwrap_or(true))
     }
 
     async fn relay_invalidate_tokens(
         &self,
-        _peer_id: &str,
+        peer_id: &str,
         _content_id: &str,
         _auth_token: &str,
         _request_signature: &[u8],
         _timestamp: Option<u64>,
     ) -> Result<bool> {
+        *self.relay_invalidate_tokens_calls.lock().await += 1;
+        self.relay_invalidate_tokens_peers
+            .lock()
+            .await
+            .push(peer_id.to_string());
         Ok(self
             .relay_invalidate_tokens_result
             .lock()

--- a/monas-state-node/src/test_utils.rs
+++ b/monas-state-node/src/test_utils.rs
@@ -456,6 +456,12 @@ impl ContentRepository for MockContentRepository {
         Ok(self.contents.lock().await.contains_key(genesis_cid))
     }
 
+    async fn has_genesis(&self, genesis_cid: &str) -> Result<bool> {
+        // The mock has no partial-DAG concept: a content is present with its
+        // genesis or absent entirely, so this mirrors `exists`.
+        Ok(self.contents.lock().await.contains_key(genesis_cid))
+    }
+
     async fn list_contents(&self) -> Result<Vec<String>> {
         Ok(self.contents.lock().await.keys().cloned().collect())
     }


### PR DESCRIPTION
example-ui をローカル4ノードで動かすために必要な state-node の relay / 書き込みルーティング系の不具合を**まとめて根治**する統合 PR です。**#49 と #52 を置き換えます**(両 PR はクローズ)。

実機4ノードクラスタ(creator + 3 member, MIN_REPLICATION_FACTOR=3)でフル e2e(作成→更新(relay)→権限→同期→invalidate)が **全 green** になることを確認済み。

## 含まれる修正(独立した3バグ)

### 1. DHT による member 発見で relay/read を成立(#52, bug #93)
relay/sync/read がローカルの `ContentNetwork` member 一覧にしか依存しておらず、記録を持たないノードが受けると 404 になっていた。`resolve_members`(ローカル記録 or DHT `find_closest_peers`)で member を発見し、`*_content_inner(from_relay)` + `*_via_relay` で 1-hop ガード(再 relay 防止)、read 側は `ensure_content_local` で member から ops を pull。→ どのノードに繋いでもリクエストが透過する。

### 2. 書き込みを genesis-node の保有で振り分け(#49 を堅牢化)
local 書き込みか relay かの判定を、メンバーシップ(`has_member_str`)ではなく **「genesis node を実際に保有しているか」** で行う。
- 当初 #49 は `exists`(=`latest().is_some()`)で判定していたが、**実機で破れた**: 部分 sync で version operations だけ import されると `exists` が `true` に化け、genesis node が無いまま local commit → "Genesis not found" → 500。
- そこで `has_genesis`(`dag.get_node(genesis)` で genesis node 自体を確認)を追加し、これで判定。crsl_lib の commit 失敗条件(genesis node を辿れないと "Genesis not found")と一致するため化けない。

### 3. redundancy check の self-capacity 誤判定を修正(真因)
**これが creator-side HTTP 500 の最上流の真因**。`check_and_maintain_redundancy` が自分自身を含む全 member に capacity query を投げていたが、libp2p は自ノード宛の request を配送しないため self-query がタイムアウト → `unwrap_or(0)` で **0 bytes** と誤判定 → 「健全 member 不足」→ 不要なメンバー追加が発火 → creator が巻き込まれて member 昇格(self-promotion)→ 部分 sync → 後続の書き込みで 500、という連鎖の起点だった。
- 修正: capacity query から自分を除外し、自ノードは healthy として直接カウント(実行中なのだから当然 healthy)。

## なぜ3つとも要るか
- **#3(self-capacity)** が真因。これだけで実機の 500 は消える(不要なメンバー追加が止まり、creator が member 化されない)。
- **#2(genesis 判定)** は、正当に member 再選出されたノードが「まだ genesis を sync していない」過渡状態でも 500 にせず relay する保険。`exists` ベースだと化けるため `has_genesis` で堅牢化。
- **#1(DHT relay)** は任意ノード透過性(404 解消)で、example-ui のフロー全体に必要。

## プライバシー / 設計
すべての判定は各ノードのローカル状態のみで行い、「どのノードが creator か」という情報を ContentNetwork・イベント・永続化のいずれにも保存・伝播しません。

## 検証
- 実機4ノードフル e2e green(invalidate が **HTTP 200**、修正前は 500)。全ノードで `low capacity (0 bytes)` / `need N more` / `ManagerAdded`(self-promotion) / `Genesis not found` / creator-side `cycle detected` が **0 件**。
- `cargo test -p monas-state-node` 全 green(294 unit + 32 integration + e2e + public-key)。`cargo clippy --all-targets` 警告なし。
- ネガティブコントロール確認済み: 判定を membership に戻すと genesis-absent relay テストが落ちる。

## スコープ外(別件)
- crsl_lib の "cycle detected in graph"(部分 DAG import の症状)自体。本 PR で creator-side の発生は消えるが、通常 sync 競合の少数発生は別問題。
- sync の `since_version=genesis` が Create をスキップする件(genesis を持たないノードに genesis node を届けにくい構造)。今回は #3 で「そもそも未同期ノードを member 化しない」+ #2 で「未同期なら relay」で実害を回避。
- #92(削除後の genesis GC)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)