### PR TITLE
fix(state-node): relay reads to members with member-side authorization; fix read auth + phantom history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3111,12 +3111,10 @@ dependencies = [
 name = "monas-content"
 version = "0.1.0"
 dependencies = [
- "aes",
  "aes-gcm",
  "axum 0.8.8",
  "base64 0.22.1",
  "chrono",
- "ctr",
  "dyn-clone",
  "hex",
  "hkdf",

--- a/monas-content/Cargo.toml
+++ b/monas-content/Cargo.toml
@@ -11,8 +11,6 @@ path = "src/lib.rs"
 [dependencies]
 monas-filesync = { path = "../monas-filesync", optional = true }
 aes-gcm = "0.10.3"
-aes = "0.8"
-ctr = "0.9"
 rand_core = { version = "0.6.4", features = ["std"] }
 rand = "0.8.5"
 chrono = { version = "0.4.40", features = ["serde"] }

--- a/monas-content/src/application_service/content_service/service.rs
+++ b/monas-content/src/application_service/content_service/service.rs
@@ -1135,6 +1135,47 @@ mod tests {
     }
 
     #[test]
+    fn fetch_encrypted_returns_stored_ciphertext() {
+        let (repo, _storage) = TestContentRepository::new(false);
+        let (key_store, _key_storage) = TestKeyStore::new(false, false);
+        let service = build_service(repo, TestKeyGenerator, TestEncryptor, key_store);
+
+        let created = service
+            .create(CreateContentCommand {
+                name: "test".into(),
+                path: "path.txt".into(),
+                raw_content: b"hello".to_vec(),
+                provider: None,
+            })
+            .expect("create should succeed");
+
+        let encrypted = service
+            .fetch_encrypted(created.content_id.clone())
+            .expect("fetch_encrypted should succeed");
+        // Contract: exactly the ciphertext produced at create time — the same
+        // bytes create() sent to the state node, so the verify-integrity
+        // comparison holds. (The test encryptor may be identity, so comparing
+        // against the plaintext would be meaningless here.)
+        assert_eq!(encrypted, created.encrypted_content);
+
+        // Round-trip sanity: the plaintext fetch decrypts the same bytes.
+        let fetched = service
+            .fetch(created.content_id, None)
+            .expect("fetch should succeed");
+        assert_eq!(fetched.raw_content, b"hello".to_vec());
+    }
+
+    #[test]
+    fn fetch_encrypted_not_found_for_unknown_content() {
+        let (repo, _) = TestContentRepository::new(false);
+        let (key_store, _) = TestKeyStore::new(false, false);
+        let service = build_service(repo, TestKeyGenerator, TestEncryptor, key_store);
+
+        let result = service.fetch_encrypted(ContentId::new("missing".to_string()));
+        assert!(matches!(result, Err(FetchError::NotFound)));
+    }
+
+    #[test]
     fn create_validation_error_when_name_is_empty() {
         let (repo, _) = TestContentRepository::new(false);
         let (key_store, _) = TestKeyStore::new(false, false);

--- a/monas-content/src/application_service/content_service/service.rs
+++ b/monas-content/src/application_service/content_service/service.rs
@@ -237,6 +237,29 @@ where
         })
     }
 
+    /// ローカルに保存された「暗号化済み」バイト列を取得する。
+    ///
+    /// State Node 整合性検証用途：State Node が保持するのは SDK が送信した
+    /// 暗号文なので、復号せずローカル暗号文とバイト比較することで
+    /// 「State Node が改ざんされていない同一の暗号文を保持しているか」を
+    /// 確認できる。
+    pub fn fetch_encrypted(&self, content_id: ContentId) -> Result<Vec<u8>, FetchError> {
+        let content = self
+            .content_repository
+            .find_by_id(&content_id)
+            .map_err(FetchError::Repository)?
+            .ok_or(FetchError::NotFound)?;
+
+        if content.is_deleted() {
+            return Err(FetchError::Deleted);
+        }
+
+        content
+            .encrypted_content()
+            .cloned()
+            .ok_or(FetchError::NotFound)
+    }
+
     /// 外部でアンラップされた CEK と暗号化済みコンテンツを用いて復号するユースケース。
     ///
     /// - 共有フロー（Share）で KeyEnvelope から CEK を取り出した後の復号処理を想定。

--- a/monas-content/src/infrastructure/encryption.rs
+++ b/monas-content/src/infrastructure/encryption.rs
@@ -3,12 +3,9 @@ use crate::domain::content::encryption::{
 };
 use crate::domain::content::ContentError;
 
-use aes::Aes256;
-use ctr::cipher::{KeyIvInit, StreamCipher};
-use ctr::Ctr128BE;
+use aes_gcm::aead::Aead;
+use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
 use rand_core::{OsRng, RngCore};
-
-type Aes256Ctr = Ctr128BE<Aes256>;
 
 /// Implementation for generating a CEK suitable for AES-256.
 ///
@@ -24,18 +21,23 @@ impl ContentEncryptionKeyGenerator for OsRngContentEncryptionKeyGenerator {
     }
 }
 
-/// Content encryption/decryption implementation using AES-256-CTR.
+/// Content encryption/decryption implementation using AES-256-GCM (AEAD).
 ///
-/// - Encryption: generates a 16-byte random IV and returns a byte sequence in the form `[iv || ciphertext]`.
-/// - Decryption: splits the first 16 bytes as the IV and uses the remaining bytes as the ciphertext for AES-CTR.
-/// - Provides confidentiality only; no integrity/authentication (no MAC or AEAD).
-///   In the future this may be replaced with an AEAD scheme such as AES-GCM to add integrity protection.
-pub struct Aes256CtrContentEncryption;
+/// - Encryption: generates a 12-byte random nonce and returns a byte sequence
+///   in the form `[nonce || ciphertext || tag]` (the 16-byte authentication
+///   tag is appended by AES-GCM).
+/// - Decryption: splits the first 12 bytes as the nonce and authenticates the
+///   remaining bytes before returning the plaintext. Any tampering with the
+///   ciphertext (including a forged payload substituted by an untrusted node)
+///   fails authentication and returns a `DecryptionError` instead of silently
+///   yielding corrupted plaintext.
+pub struct Aes256GcmContentEncryption;
 
-const IV_LEN: usize = 16;
+const NONCE_LEN: usize = 12;
+const TAG_LEN: usize = 16;
 const KEY_LEN: usize = 32;
 
-impl ContentEncryption for Aes256CtrContentEncryption {
+impl ContentEncryption for Aes256GcmContentEncryption {
     fn encrypt(
         &self,
         key: &ContentEncryptionKey,
@@ -48,21 +50,24 @@ impl ContentEncryption for Aes256CtrContentEncryption {
                 key.0.len()
             )));
         }
-        let mut iv = [0u8; IV_LEN];
-        let mut rng = OsRng;
-        rng.fill_bytes(&mut iv);
-
-        let mut buffer = plaintext.to_vec();
-        let mut cipher = Aes256Ctr::new_from_slices(key.0.as_slice(), &iv).map_err(|_| {
+        let cipher = Aes256Gcm::new_from_slice(key.0.as_slice()).map_err(|_| {
             ContentError::EncryptionError(
-                "Invalid key or IV length for AES-256-CTR (expected 32-byte key, 16-byte IV)"
-                    .into(),
+                "Invalid key length for AES-256-GCM (expected 32-byte key)".into(),
             )
         })?;
-        cipher.apply_keystream(&mut buffer);
-        let mut result = Vec::with_capacity(IV_LEN + buffer.len());
-        result.extend_from_slice(&iv);
-        result.extend_from_slice(&buffer);
+
+        let mut nonce_bytes = [0u8; NONCE_LEN];
+        let mut rng = OsRng;
+        rng.fill_bytes(&mut nonce_bytes);
+        let nonce = Nonce::from_slice(&nonce_bytes);
+
+        let ciphertext = cipher
+            .encrypt(nonce, plaintext)
+            .map_err(|_| ContentError::EncryptionError("AES-256-GCM encryption failed".into()))?;
+
+        let mut result = Vec::with_capacity(NONCE_LEN + ciphertext.len());
+        result.extend_from_slice(&nonce_bytes);
+        result.extend_from_slice(&ciphertext);
         Ok(result)
     }
 
@@ -75,26 +80,26 @@ impl ContentEncryption for Aes256CtrContentEncryption {
             )));
         }
 
-        if data.len() <= IV_LEN {
+        if data.len() < NONCE_LEN + TAG_LEN {
             return Err(ContentError::DecryptionError(
-                "Ciphertext is too short to contain IV and data (must be longer than IV only)"
-                    .into(),
+                "Ciphertext is too short to contain nonce and authentication tag".into(),
             ));
         }
 
-        let (iv_bytes, ciphertext) = data.split_at(IV_LEN);
-
-        let mut buffer = ciphertext.to_vec();
-
-        let mut cipher = Aes256Ctr::new_from_slices(key.0.as_slice(), iv_bytes).map_err(|_| {
+        let (nonce_bytes, ciphertext) = data.split_at(NONCE_LEN);
+        let cipher = Aes256Gcm::new_from_slice(key.0.as_slice()).map_err(|_| {
             ContentError::DecryptionError(
-                "Invalid key or IV length for AES-256-CTR (expected 32-byte key, 16-byte IV)"
-                    .into(),
+                "Invalid key length for AES-256-GCM (expected 32-byte key)".into(),
             )
         })?;
-        cipher.apply_keystream(&mut buffer);
 
-        Ok(buffer)
+        cipher
+            .decrypt(Nonce::from_slice(nonce_bytes), ciphertext)
+            .map_err(|_| {
+                ContentError::DecryptionError(
+                    "AES-256-GCM authentication failed: ciphertext is corrupted or tampered".into(),
+                )
+            })
     }
 }
 
@@ -105,7 +110,7 @@ mod tests {
     #[test]
     fn encrypt_then_decrypt_round_trip() {
         let key = ContentEncryptionKey(vec![42u8; 32]); // fixed key only for testing
-        let encryptor = Aes256CtrContentEncryption;
+        let encryptor = Aes256GcmContentEncryption;
         let plaintext = b"Monas content encryption test".to_vec();
 
         let ciphertext = encryptor
@@ -113,8 +118,7 @@ mod tests {
             .expect("encryption should succeed");
 
         assert_ne!(ciphertext, plaintext);
-        assert!(ciphertext.len() > plaintext.len());
-        assert!(ciphertext.len() >= IV_LEN);
+        assert_eq!(ciphertext.len(), NONCE_LEN + plaintext.len() + TAG_LEN);
 
         let decrypted = encryptor
             .decrypt(&key, &ciphertext)
@@ -126,7 +130,7 @@ mod tests {
     #[test]
     fn encrypt_fails_with_invalid_key_length() {
         let key = ContentEncryptionKey(vec![1u8; 16]);
-        let encryptor = Aes256CtrContentEncryption;
+        let encryptor = Aes256GcmContentEncryption;
         let plaintext = b"test".to_vec();
 
         let result = encryptor.encrypt(&key, &plaintext);
@@ -136,9 +140,9 @@ mod tests {
     #[test]
     fn decrypt_fails_with_invalid_key_length() {
         let key = ContentEncryptionKey(vec![1u8; 16]);
-        let encryptor = Aes256CtrContentEncryption;
+        let encryptor = Aes256GcmContentEncryption;
 
-        let dummy_ciphertext = vec![0u8; IV_LEN + 4];
+        let dummy_ciphertext = vec![0u8; NONCE_LEN + TAG_LEN + 4];
 
         let result = encryptor.decrypt(&key, &dummy_ciphertext);
         assert!(matches!(result, Err(ContentError::DecryptionError(_))));
@@ -147,21 +151,22 @@ mod tests {
     #[test]
     fn decrypt_fails_when_data_too_short() {
         let key = ContentEncryptionKey(vec![2u8; 32]);
-        let encryptor = Aes256CtrContentEncryption;
+        let encryptor = Aes256GcmContentEncryption;
 
-        let too_short = vec![0u8; IV_LEN]; // exactly IV length (no payload data)
+        // nonce + tag だけの長さ未満は即エラー
+        let too_short = vec![0u8; NONCE_LEN + TAG_LEN - 1];
         let result = encryptor.decrypt(&key, &too_short);
         assert!(matches!(result, Err(ContentError::DecryptionError(_))));
 
-        let even_shorter = vec![0u8; IV_LEN - 1];
+        let even_shorter = vec![0u8; NONCE_LEN];
         let result2 = encryptor.decrypt(&key, &even_shorter);
         assert!(matches!(result2, Err(ContentError::DecryptionError(_))));
     }
 
     #[test]
-    fn encrypt_produces_different_ciphertexts_due_to_random_iv() {
+    fn encrypt_produces_different_ciphertexts_due_to_random_nonce() {
         let key = ContentEncryptionKey(vec![99u8; 32]);
-        let encryptor = Aes256CtrContentEncryption;
+        let encryptor = Aes256GcmContentEncryption;
         let plaintext = b"same plaintext".to_vec();
 
         let c1 = encryptor
@@ -177,7 +182,7 @@ mod tests {
     #[test]
     fn encrypt_then_decrypt_round_trip_large_plaintext() {
         let key = ContentEncryptionKey(vec![7u8; 32]);
-        let encryptor = Aes256CtrContentEncryption;
+        let encryptor = Aes256GcmContentEncryption;
         let size = 1024 * 1024;
         let mut plaintext = Vec::with_capacity(size);
         for i in 0..size {
@@ -188,8 +193,7 @@ mod tests {
             .encrypt(&key, &plaintext)
             .expect("encryption should succeed for large plaintext");
 
-        assert!(ciphertext.len() > plaintext.len());
-        assert!(ciphertext.len() >= IV_LEN);
+        assert_eq!(ciphertext.len(), NONCE_LEN + plaintext.len() + TAG_LEN);
 
         let decrypted = encryptor
             .decrypt(&key, &ciphertext)
@@ -198,98 +202,88 @@ mod tests {
         assert_eq!(decrypted, plaintext);
     }
 
-    /// **Security vulnerability test**: This test passing demonstrates lack of integrity verification
+    /// **Integrity test**: AES-GCM detects any tampering of the ciphertext.
     ///
-    /// In AES-CTR mode, decryption succeeds even when ciphertext is tampered with.
-    /// Tampering goes undetected and incorrect data is returned.
-    ///
-    /// **Expected behavior (ideal)**: Tampered ciphertext should be detected and decryption should fail
-    /// **Current behavior (problem)**: Test passes = tampering undetected = security vulnerability
+    /// This is the counterpart of the old AES-CTR "vulnerability demo" test:
+    /// with CTR, a bit-flipped ciphertext decrypted "successfully" into
+    /// attacker-controlled plaintext. With GCM the authentication tag no
+    /// longer matches, so decryption MUST fail. This is what protects the SDK
+    /// from forged payloads returned by untrusted state nodes (PR #54 review).
     #[test]
-    fn tampered_ciphertext_decrypts_successfully_but_returns_wrong_data() {
+    fn tampered_ciphertext_fails_authentication() {
         let key = ContentEncryptionKey(vec![42u8; 32]);
-        let encryptor = Aes256CtrContentEncryption;
+        let encryptor = Aes256GcmContentEncryption;
         let plaintext = b"Secret message that should not be tampered with!";
 
-        println!("\n========== TEST 1: Tampered Ciphertext ==========");
-        println!(
-            "Original Plaintext: {:?}",
-            String::from_utf8_lossy(plaintext)
-        );
-        println!("Plaintext (hex):    {}", hex::encode(plaintext));
-        println!("Plaintext length:   {} bytes", plaintext.len());
-
-        // Encrypt normally
         let mut ciphertext = encryptor
             .encrypt(&key, plaintext)
             .expect("encryption should succeed");
 
-        println!("\n--- After Encryption ---");
-        println!(
-            "Ciphertext length:  {} bytes (IV: {} + data: {})",
-            ciphertext.len(),
-            IV_LEN,
-            ciphertext.len() - IV_LEN
-        );
-        println!(
-            "IV (first 16 bytes):       {}",
-            hex::encode(&ciphertext[0..IV_LEN])
-        );
-        println!(
-            "Encrypted data (hex):      {}",
-            hex::encode(&ciphertext[IV_LEN..])
+        // Flip one bit in the encrypted payload (right after the nonce)
+        ciphertext[NONCE_LEN] ^= 0x11;
+
+        let result = encryptor.decrypt(&key, &ciphertext);
+        assert!(
+            matches!(result, Err(ContentError::DecryptionError(_))),
+            "tampered ciphertext must fail GCM authentication"
         );
 
-        // Tamper with part of the ciphertext (modify the first byte after IV)
-        let original_byte = ciphertext[IV_LEN];
-        println!("\n--- Before Tampering ---");
-        println!("Byte at position [IV_LEN=16]: 0x{original_byte:02x} ({original_byte})");
-
-        ciphertext[IV_LEN] ^= 0x11; // Tampering by bit flipping
-        println!("\n--- After Tampering ---");
-        let _tampered_byte = ciphertext[IV_LEN];
-        println!(
-            "Byte at position [IV_LEN=16]: 0x{tampered:02x} ({tampered}) ← TAMPERED!",
-            tampered = ciphertext[IV_LEN]
-        );
-        println!(
-            "Modified ciphertext (hex):     {}",
-            hex::encode(&ciphertext[IV_LEN..])
-        );
-
-        // Problem: Decryption "succeeds" even with tampered ciphertext
-        let decrypted = encryptor
-            .decrypt(&key, &ciphertext)
-            .expect("decryption 'succeeds' even with tampered data - THIS IS THE PROBLEM!");
-
-        println!("\n--- Decryption of Tampered Data ---");
-        println!("WARNING: Decryption SUCCEEDED (this is the problem!)");
-        println!("Decrypted text:  {:?}", String::from_utf8_lossy(&decrypted));
-        println!("Decrypted (hex): {}", hex::encode(&decrypted));
-
-        // Due to tampering, the decrypted result differs from the original first byte
-        println!("\n--- Verification ---");
-        println!(
-            "Original 1st byte:  0x{:02x} ({})",
-            plaintext[0], plaintext[0] as char
-        );
-        println!(
-            "Decrypted 1st byte: 0x{:02x} ({})",
-            decrypted[0], decrypted[0] as char
-        );
-        assert_ne!(decrypted[0], plaintext[0]);
-        assert_ne!(&decrypted[..], &plaintext[..]);
-        println!("OK: Decrypted data DIFFERS from original (as expected from tampering)");
-
-        // Restoring the original byte allows correct decryption (proof that tampering was the cause)
-        println!("\n--- Restoring Original Ciphertext ---");
-        ciphertext[IV_LEN] = original_byte;
+        // Restoring the original byte makes decryption succeed again,
+        // proving the failure above was caused by the tampering.
+        ciphertext[NONCE_LEN] ^= 0x11;
         let restored = encryptor
             .decrypt(&key, &ciphertext)
-            .expect("should decrypt");
-        println!("Restored text: {:?}", String::from_utf8_lossy(&restored));
+            .expect("untampered ciphertext should decrypt");
         assert_eq!(&restored[..], &plaintext[..]);
-        println!("OK: After restoring byte, plaintext matches original");
-        println!("========== END TEST 1 ==========\n");
+    }
+
+    /// Tampering with the nonce is also detected (the tag authenticates the
+    /// nonce implicitly via the keystream).
+    #[test]
+    fn tampered_nonce_fails_authentication() {
+        let key = ContentEncryptionKey(vec![42u8; 32]);
+        let encryptor = Aes256GcmContentEncryption;
+        let plaintext = b"nonce integrity";
+
+        let mut ciphertext = encryptor
+            .encrypt(&key, plaintext)
+            .expect("encryption should succeed");
+        ciphertext[0] ^= 0x01;
+
+        let result = encryptor.decrypt(&key, &ciphertext);
+        assert!(matches!(result, Err(ContentError::DecryptionError(_))));
+    }
+
+    /// Tampering with the authentication tag itself is detected.
+    #[test]
+    fn tampered_tag_fails_authentication() {
+        let key = ContentEncryptionKey(vec![42u8; 32]);
+        let encryptor = Aes256GcmContentEncryption;
+        let plaintext = b"tag integrity";
+
+        let mut ciphertext = encryptor
+            .encrypt(&key, plaintext)
+            .expect("encryption should succeed");
+        let last = ciphertext.len() - 1;
+        ciphertext[last] ^= 0x80;
+
+        let result = encryptor.decrypt(&key, &ciphertext);
+        assert!(matches!(result, Err(ContentError::DecryptionError(_))));
+    }
+
+    /// Decrypting with a wrong key fails instead of returning garbage.
+    #[test]
+    fn wrong_key_fails_authentication() {
+        let key = ContentEncryptionKey(vec![42u8; 32]);
+        let wrong_key = ContentEncryptionKey(vec![43u8; 32]);
+        let encryptor = Aes256GcmContentEncryption;
+        let plaintext = b"key binding";
+
+        let ciphertext = encryptor
+            .encrypt(&key, plaintext)
+            .expect("encryption should succeed");
+
+        let result = encryptor.decrypt(&wrong_key, &ciphertext);
+        assert!(matches!(result, Err(ContentError::DecryptionError(_))));
     }
 }

--- a/monas-content/src/presentation/mod.rs
+++ b/monas-content/src/presentation/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     application_service::{content_service::ContentService, share_service::ShareService},
     infrastructure::{
         content_id::Sha256ContentIdGenerator,
-        encryption::{Aes256CtrContentEncryption, OsRngContentEncryptionKeyGenerator},
+        encryption::{Aes256GcmContentEncryption, OsRngContentEncryptionKeyGenerator},
         key_store::InMemoryContentEncryptionKeyStore,
         key_wrapping::HpkeV1KeyWrapping,
         public_key_directory::InMemoryPublicKeyDirectory,
@@ -36,7 +36,7 @@ struct AppState {
             Sha256ContentIdGenerator,
             MultiStorageRepository,
             OsRngContentEncryptionKeyGenerator,
-            Aes256CtrContentEncryption,
+            Aes256GcmContentEncryption,
             InMemoryContentEncryptionKeyStore,
         >,
     >,
@@ -68,7 +68,7 @@ pub fn create_router() -> Router {
         content_id_generator: Sha256ContentIdGenerator,
         content_repository: content_repository.clone(),
         key_generator: OsRngContentEncryptionKeyGenerator,
-        encryptor: Aes256CtrContentEncryption,
+        encryptor: Aes256GcmContentEncryption,
         cek_store: cek_store.clone(),
     };
 

--- a/monas-event-manager/src/event_subscription.rs
+++ b/monas-event-manager/src/event_subscription.rs
@@ -485,7 +485,7 @@ impl EventSubscriptions {
         let subscriptions = self.subscriptions.read().await;
         let mut health_status = HashMap::new();
 
-        for (_, subscribers) in subscriptions.iter() {
+        for subscribers in subscriptions.values() {
             for subscriber in subscribers {
                 let status = if subscriber.is_healthy().await {
                     ConnectionStatus::Connected
@@ -505,7 +505,7 @@ impl EventSubscriptions {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let subscriptions = self.subscriptions.read().await;
         let persistence = self.dead_letter_manager.as_ref();
-        for (_, subscribers) in subscriptions.iter() {
+        for subscribers in subscriptions.values() {
             for subscriber in subscribers {
                 subscriber.process_retry_queue(persistence).await;
             }
@@ -579,7 +579,7 @@ impl EventSubscriptions {
         let subscriptions = self.subscriptions.read().await;
 
         // Add to retry queue of all subscribers
-        for (_, subscribers) in subscriptions.iter() {
+        for subscribers in subscriptions.values() {
             for subscriber in subscribers {
                 subscriber.add_to_retry_queue(message.clone()).await;
             }

--- a/monas-sdk/src/controller/content.rs
+++ b/monas-sdk/src/controller/content.rs
@@ -217,7 +217,7 @@ impl MonasController {
             .map(Some)
     }
 
-    fn prepare_state_node_metadata_auth<T>(
+    pub(super) fn prepare_state_node_metadata_auth<T>(
         &self,
         auth: Option<&StateNodeAuthContext>,
         operation: &str,

--- a/monas-sdk/src/controller/content.rs
+++ b/monas-sdk/src/controller/content.rs
@@ -24,7 +24,7 @@ use monas_content::domain::content::{Content, ContentEncryptionKey, StorageProvi
 use monas_content::domain::content_id::ContentId;
 use monas_content::infrastructure::{
     content_id::Sha256ContentIdGenerator,
-    encryption::{Aes256CtrContentEncryption, OsRngContentEncryptionKeyGenerator},
+    encryption::{Aes256GcmContentEncryption, OsRngContentEncryptionKeyGenerator},
     MultiStorageRepository,
 };
 
@@ -38,7 +38,7 @@ pub(super) type ContentServiceInstance = ContentService<
     Sha256ContentIdGenerator,
     MultiStorageRepository,
     OsRngContentEncryptionKeyGenerator,
-    Aes256CtrContentEncryption,
+    Aes256GcmContentEncryption,
     DynCekStore,
 >;
 

--- a/monas-sdk/src/controller/mod.rs
+++ b/monas-sdk/src/controller/mod.rs
@@ -262,14 +262,14 @@ impl MonasController {
         use monas_content::application_service::content_service::ContentService;
         use monas_content::infrastructure::{
             content_id::Sha256ContentIdGenerator,
-            encryption::{Aes256CtrContentEncryption, OsRngContentEncryptionKeyGenerator},
+            encryption::{Aes256GcmContentEncryption, OsRngContentEncryptionKeyGenerator},
         };
 
         ContentService {
             content_id_generator: Sha256ContentIdGenerator,
             content_repository,
             key_generator: OsRngContentEncryptionKeyGenerator,
-            encryptor: Aes256CtrContentEncryption,
+            encryptor: Aes256GcmContentEncryption,
             cek_store,
         }
     }

--- a/monas-sdk/src/controller/share.rs
+++ b/monas-sdk/src/controller/share.rs
@@ -517,8 +517,14 @@ impl MonasController {
             }
         };
 
+        // State Node は系列ID（remote_content_id）でコンテンツを管理する。
+        // ローカル版IDしか送らないと State Node 側で未知のコンテンツ扱いになる。
+        let state_node_content_id = input
+            .remote_content_id
+            .as_deref()
+            .unwrap_or(&input.content_id);
         if let Some(response) = self.send_update_to_state_node(
-            &input.content_id,
+            state_node_content_id,
             &reencryption.encrypted_content,
             auth,
             trace_id.clone(),

--- a/monas-sdk/src/controller/state.rs
+++ b/monas-sdk/src/controller/state.rs
@@ -24,6 +24,26 @@ impl MonasController {
         None
     }
 
+    /// State Node の読み取り API 用の認証コンテキストを解決する。
+    ///
+    /// 呼び出し元が Authorization を明示していればそのまま透過する。
+    /// 無ければ書き込み系（create/update/delete）と同じく monas-account で
+    /// `read:content:<timestamp>` に署名し、`user:<hex(pubkey)>` トークンを組み立てる。
+    /// State Node 側は読み取り時にこの署名メッセージを検証する
+    /// （`verify_read_access` → `verify_caller_signature("read", "content", ..)`）。
+    fn resolve_state_read_auth<T>(
+        &self,
+        auth: Option<&StateNodeAuthContext>,
+        trace_id: &str,
+    ) -> Result<Option<StateNodeAuthContext>, ApiResponse<T>> {
+        match auth {
+            Some(ctx) if ctx.authorization.is_none() => {
+                self.prepare_state_node_metadata_auth(auth, "read", "content", trace_id)
+            }
+            _ => Ok(auth.cloned()),
+        }
+    }
+
     fn state_node_get_string<T>(
         &self,
         url: &str,
@@ -118,9 +138,13 @@ impl MonasController {
             return response;
         }
 
+        let auth = match self.resolve_state_read_auth::<GetLatestVersionOutput>(auth, &trace_id) {
+            Ok(resolved) => resolved,
+            Err(e) => return e,
+        };
         let history = match self.get_state_node_history::<GetLatestVersionOutput>(
             &input.content_id,
-            auth,
+            auth.as_ref(),
             trace_id.clone(),
         ) {
             Ok(h) => h,
@@ -158,9 +182,13 @@ impl MonasController {
             return response;
         }
 
+        let auth = match self.resolve_state_read_auth::<GetHistoryOutput>(auth, &trace_id) {
+            Ok(resolved) => resolved,
+            Err(e) => return e,
+        };
         let history = match self.get_state_node_history::<GetHistoryOutput>(
             &input.content_id,
-            auth,
+            auth.as_ref(),
             trace_id.clone(),
         ) {
             Ok(h) => h,
@@ -209,6 +237,12 @@ impl MonasController {
                 trace_id,
             );
         }
+
+        let auth = match self.resolve_state_read_auth::<VerifyIntegrityOutput>(auth, &trace_id) {
+            Ok(resolved) => resolved,
+            Err(e) => return e,
+        };
+        let auth = auth.as_ref();
 
         let content_bytes = match URL_SAFE_NO_PAD.decode(&input.content) {
             Ok(b) => b,

--- a/monas-sdk/src/controller/state.rs
+++ b/monas-sdk/src/controller/state.rs
@@ -28,17 +28,20 @@ impl MonasController {
     ///
     /// 呼び出し元が Authorization を明示していればそのまま透過する。
     /// 無ければ書き込み系（create/update/delete）と同じく monas-account で
-    /// `read:content:<timestamp>` に署名し、`user:<hex(pubkey)>` トークンを組み立てる。
+    /// `read:<content_id>:<timestamp>` に署名し、`user:<hex(pubkey)>` トークンを組み立てる。
     /// State Node 側は読み取り時にこの署名メッセージを検証する
-    /// （`verify_read_access` → `verify_caller_signature("read", "content", ..)`）。
+    /// （`verify_read_access` → `verify_caller_signature("read", content_id, ..)`）。
+    /// 署名を content_id にバインドすることで、relay 先ノード等に渡った署名を
+    /// 他コンテンツの読み取りに再利用されることを防ぐ。
     fn resolve_state_read_auth<T>(
         &self,
         auth: Option<&StateNodeAuthContext>,
+        content_id: &str,
         trace_id: &str,
     ) -> Result<Option<StateNodeAuthContext>, ApiResponse<T>> {
         match auth {
             Some(ctx) if ctx.authorization.is_none() => {
-                self.prepare_state_node_metadata_auth(auth, "read", "content", trace_id)
+                self.prepare_state_node_metadata_auth(auth, "read", content_id, trace_id)
             }
             _ => Ok(auth.cloned()),
         }
@@ -138,7 +141,11 @@ impl MonasController {
             return response;
         }
 
-        let auth = match self.resolve_state_read_auth::<GetLatestVersionOutput>(auth, &trace_id) {
+        let auth = match self.resolve_state_read_auth::<GetLatestVersionOutput>(
+            auth,
+            &input.content_id,
+            &trace_id,
+        ) {
             Ok(resolved) => resolved,
             Err(e) => return e,
         };
@@ -182,7 +189,11 @@ impl MonasController {
             return response;
         }
 
-        let auth = match self.resolve_state_read_auth::<GetHistoryOutput>(auth, &trace_id) {
+        let auth = match self.resolve_state_read_auth::<GetHistoryOutput>(
+            auth,
+            &input.content_id,
+            &trace_id,
+        ) {
             Ok(resolved) => resolved,
             Err(e) => return e,
         };
@@ -238,7 +249,11 @@ impl MonasController {
             );
         }
 
-        let auth = match self.resolve_state_read_auth::<VerifyIntegrityOutput>(auth, &trace_id) {
+        let auth = match self.resolve_state_read_auth::<VerifyIntegrityOutput>(
+            auth,
+            &input.content_id,
+            &trace_id,
+        ) {
             Ok(resolved) => resolved,
             Err(e) => return e,
         };

--- a/monas-sdk/src/controller/state.rs
+++ b/monas-sdk/src/controller/state.rs
@@ -298,13 +298,44 @@ impl MonasController {
             }
         };
 
-        let valid = content_bytes == state_bytes;
-        let reason = if valid {
-            None
+        // State Node が保持するのは SDK が送信した「暗号文」なので、
+        // local_content_id があればローカルに保存された暗号文とバイト比較する。
+        // （平文 `content` と State Node のバイト列は一致し得ない。）
+        let (valid, reason) = if let Some(local_id) = input.local_content_id.as_deref() {
+            match self.content_service.fetch_encrypted(
+                monas_content::domain::content_id::ContentId::new(local_id.to_string()),
+            ) {
+                Ok(local_cipher) => {
+                    if local_cipher == state_bytes {
+                        (true, None)
+                    } else {
+                        (
+                            false,
+                            Some(format!(
+                                "state node ciphertext differs from local ciphertext (version={version_to_check})"
+                            )),
+                        )
+                    }
+                }
+                Err(e) => (
+                    false,
+                    Some(format!(
+                        "failed to load local ciphertext for {local_id}: {e}"
+                    )),
+                ),
+            }
         } else {
-            Some(format!(
-                "content mismatch with state node (version={version_to_check})"
-            ))
+            let valid = content_bytes == state_bytes;
+            (
+                valid,
+                if valid {
+                    None
+                } else {
+                    Some(format!(
+                        "content mismatch with state node (version={version_to_check})"
+                    ))
+                },
+            )
         };
 
         ApiResponse::success(

--- a/monas-sdk/src/models/share.rs
+++ b/monas-sdk/src/models/share.rs
@@ -75,7 +75,13 @@ pub struct DelegatedAccessToken {
 /// 共有取り消しリクエスト
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RevokeShareInput {
+    /// SDK ローカルの版ID（ACL・CEK・再暗号化はローカルIDで処理される）
     pub content_id: String,
+    /// State Node へ送る系列ID。未指定の場合は `content_id` を使う（後方互換）。
+    /// State Node はローカル版IDを知らないため、State Node に登録済みの
+    /// コンテンツでは必ず指定すること（`UpdateContentInput` と同じ区別）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_content_id: Option<String>,
     /// 送信者の公開鍵（base64url） - sender_key_idを計算するために使用
     pub sender_public_key: String,
     pub recipient_public_key: String,

--- a/monas-sdk/src/models/state.rs
+++ b/monas-sdk/src/models/state.rs
@@ -54,6 +54,12 @@ pub struct VerifyIntegrityInput {
     pub content: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expected_version: Option<String>,
+    /// SDK ローカルの版ID。指定すると、State Node が返す暗号文をローカルに
+    /// 保存された暗号文とバイト比較して検証する（State Node は暗号文を保持
+    /// するため、平文である `content` とは直接比較できない）。未指定の場合は
+    /// 従来どおり `content` のバイト列と直接比較する。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local_content_id: Option<String>,
 }
 
 /// 整合性検証レスポンス

--- a/monas-sdk/tests/share_controller_integration_test.rs
+++ b/monas-sdk/tests/share_controller_integration_test.rs
@@ -203,6 +203,96 @@ async fn revoke_share_updates_state_node_version() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn revoke_share_syncs_state_node_by_remote_content_id() {
+    // The state node only knows the series id (remote_content_id), never the
+    // SDK-local version id. The post-revoke re-encryption PUT must therefore
+    // address the remote id when it is provided.
+    let _guard = acquire_test_lock();
+    let mut server = Server::new_async().await;
+    let create_mock = server
+        .mock("POST", "/content")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"content_id":"remote-series-id"}"#)
+        .create_async()
+        .await;
+    let delegate_mock = server
+        .mock("POST", "/issuer/delegate")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            r#"{"delegated_token":"dummy.jwt.token","issued_at":1700000000,"expires_at":1700003600,"jti":"jti-3"}"#,
+        )
+        .create_async()
+        .await;
+    // Only the remote id path is mocked: a PUT to any other path (e.g. the
+    // local content id) would fail the request and the assertion below.
+    let update_mock = server
+        .mock("PUT", "/content/remote-series-id")
+        .with_status(200)
+        .create_async()
+        .await;
+
+    let controller = MonasController::with_urls(server.url(), server.url());
+
+    let sender = controller
+        .generate_keypair(GenerateKeypairInput {
+            key_type: KeyType::Secp256r1,
+        })
+        .data
+        .expect("sender keypair should be generated");
+    let recipient = controller
+        .generate_keypair(GenerateKeypairInput {
+            key_type: KeyType::Secp256r1,
+        })
+        .data
+        .expect("recipient keypair should be generated");
+
+    let create_response = controller.create_content(
+        CreateContentInput {
+            content: URL_SAFE_NO_PAD.encode(b"revoke-remote-id-content"),
+            metadata: Some(ContentMetadata {
+                name: Some("revoke-remote.txt".to_string()),
+                content_type: Some("text/plain".to_string()),
+                created_at: None,
+                updated_at: None,
+            }),
+        },
+        None,
+    );
+    assert!(create_response.success, "create_content should succeed");
+    let created = create_response.data.expect("create should return data");
+    create_mock.assert();
+
+    let share_response = controller.share_content(ShareContentInput {
+        content_id: created.content_id.clone(),
+        sender_public_key: sender.public_key.clone(),
+        recipient_public_key: recipient.public_key.clone(),
+        permissions: vec![Permission::Write],
+    });
+    assert!(share_response.success, "share_content should succeed");
+    delegate_mock.assert();
+
+    let revoke_response = controller.revoke_share(
+        RevokeShareInput {
+            content_id: created.content_id,
+            remote_content_id: Some("remote-series-id".to_string()),
+            sender_public_key: sender.public_key,
+            recipient_public_key: recipient.public_key,
+        },
+        None,
+    );
+    assert!(
+        revoke_response.success,
+        "revoke_share should succeed: {:?}",
+        revoke_response.error
+    );
+    update_mock.assert();
+
+    cleanup_content_artifacts();
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn revoke_share_rolls_back_local_state_when_state_node_sync_fails() {
     let _guard = acquire_test_lock();
     let mut server = Server::new_async().await;

--- a/monas-sdk/tests/share_controller_integration_test.rs
+++ b/monas-sdk/tests/share_controller_integration_test.rs
@@ -186,6 +186,7 @@ async fn revoke_share_updates_state_node_version() {
     let revoke_response = controller.revoke_share(
         RevokeShareInput {
             content_id: created.content_id,
+            remote_content_id: None,
             sender_public_key: sender.public_key,
             recipient_public_key: recipient.public_key,
         },
@@ -280,6 +281,7 @@ async fn revoke_share_rolls_back_local_state_when_state_node_sync_fails() {
     let revoke_response = controller.revoke_share(
         RevokeShareInput {
             content_id: created.content_id.clone(),
+            remote_content_id: None,
             sender_public_key: sender.public_key.clone(),
             recipient_public_key: recipient.public_key.clone(),
         },
@@ -317,6 +319,7 @@ async fn revoke_share_rolls_back_local_state_when_state_node_sync_fails() {
     let second_revoke_response = controller.revoke_share(
         RevokeShareInput {
             content_id: created.content_id,
+            remote_content_id: None,
             sender_public_key: sender.public_key,
             recipient_public_key: recipient.public_key,
         },
@@ -414,6 +417,7 @@ async fn revoke_share_rollback_fires_on_inner_share_service_error() {
     let first = controller.revoke_share(
         RevokeShareInput {
             content_id: created.content_id.clone(),
+            remote_content_id: None,
             sender_public_key: sender.public_key.clone(),
             recipient_public_key: recipient.public_key.clone(),
         },
@@ -432,6 +436,7 @@ async fn revoke_share_rollback_fires_on_inner_share_service_error() {
     let second = controller.revoke_share(
         RevokeShareInput {
             content_id: created.content_id,
+            remote_content_id: None,
             sender_public_key: sender.public_key,
             recipient_public_key: recipient.public_key,
         },

--- a/monas-sdk/tests/state_controller_integration_test.rs
+++ b/monas-sdk/tests/state_controller_integration_test.rs
@@ -121,6 +121,7 @@ async fn verify_integrity_rejects_stale_timestamp_with_unauthorized() {
             content_id: "test-content".into(),
             content: URL_SAFE_NO_PAD.encode(b"hello"),
             expected_version: Some("v1".into()),
+            local_content_id: None,
         },
         Some(&auth),
     );
@@ -205,6 +206,7 @@ async fn verify_integrity_returns_api_error_when_history_cannot_be_fetched() {
             content_id: "test-content".into(),
             content: URL_SAFE_NO_PAD.encode(b"hello"),
             expected_version: None,
+            local_content_id: None,
         },
         None,
     );
@@ -235,6 +237,7 @@ async fn verify_integrity_returns_api_error_when_version_cannot_be_fetched() {
             content_id: "test-content".into(),
             content: URL_SAFE_NO_PAD.encode(b"hello"),
             expected_version: Some("v1".into()),
+            local_content_id: None,
         },
         None,
     );
@@ -265,6 +268,7 @@ async fn verify_integrity_keeps_false_only_for_actual_content_mismatch() {
             content_id: "test-content".into(),
             content: URL_SAFE_NO_PAD.encode(b"hello"),
             expected_version: Some("v1".into()),
+            local_content_id: None,
         },
         None,
     );
@@ -303,6 +307,7 @@ async fn verify_integrity_returns_api_error_for_invalid_state_node_base64() {
             content_id: "test-content".into(),
             content: URL_SAFE_NO_PAD.encode(b"hello"),
             expected_version: Some("v1".into()),
+            local_content_id: None,
         },
         None,
     );

--- a/monas-state-node/scripts/e2e-test.sh
+++ b/monas-state-node/scripts/e2e-test.sh
@@ -306,7 +306,7 @@ log_step "全ノードから content データを即座に取得できるか確�
 
 IMMEDIATE_MEMBERS=0
 for port in 8080 8081 8082; do
-    generate_signature "$ACCOUNT1_PRIVATE_KEY" "read" "content"
+    generate_signature "$ACCOUNT1_PRIVATE_KEY" "read" "$CONTENT_ID"
     DATA_RESPONSE=$(curl -s "http://127.0.0.1:$port/content/$CONTENT_ID/data" \
         -H "Authorization: Bearer $ACCOUNT1_KEY_ID" \
         -H "X-Request-Signature: $LAST_SIGNATURE" \
@@ -445,7 +445,7 @@ echo ""
 updated_content_visible() {
     local p
     for p in 8080 8081 8082; do
-        generate_signature "$ACCOUNT1_PRIVATE_KEY" "read" "content"
+        generate_signature "$ACCOUNT1_PRIVATE_KEY" "read" "$CONTENT_ID"
         local resp
         resp=$(curl -s "http://127.0.0.1:$p/content/$CONTENT_ID/data" \
             -H "Authorization: Bearer $ACCOUNT1_KEY_ID" \
@@ -464,7 +464,7 @@ poll_until 15 1 updated_content_visible || log_warn "15秒以内に更新の伝�
 
 log_step "各ノードでcontentデータを取得し、更新が反映されていることを確認"
 for port in 8080 8081 8082; do
-    generate_signature "$ACCOUNT1_PRIVATE_KEY" "read" "content"
+    generate_signature "$ACCOUNT1_PRIVATE_KEY" "read" "$CONTENT_ID"
     DATA_RESPONSE=$(curl -s "http://127.0.0.1:$port/content/$CONTENT_ID/data" \
         -H "Authorization: Bearer $ACCOUNT1_KEY_ID" \
         -H "X-Request-Signature: $LAST_SIGNATURE" \
@@ -483,7 +483,7 @@ done
 log_test "少なくとも1つのノードで更新データが取得できること"
 VERIFIED=false
 for port in 8080 8081 8082; do
-    generate_signature "$ACCOUNT1_PRIVATE_KEY" "read" "content"
+    generate_signature "$ACCOUNT1_PRIVATE_KEY" "read" "$CONTENT_ID"
     DATA_RESPONSE=$(curl -s "http://127.0.0.1:$port/content/$CONTENT_ID/data" \
         -H "Authorization: Bearer $ACCOUNT1_KEY_ID" \
         -H "X-Request-Signature: $LAST_SIGNATURE" \

--- a/monas-state-node/scripts/test-with-auth.sh
+++ b/monas-state-node/scripts/test-with-auth.sh
@@ -262,7 +262,7 @@ if [ -n "$CONTENT_ID" ]; then
     echo ""
 
     # CRDTデータの取得（認証ヘッダー付き）
-    generate_signature "$TEST_PRIVATE_KEY" "read" "content"
+    generate_signature "$TEST_PRIVATE_KEY" "read" "$CONTENT_ID"
 
     log_test "CRDTデータの取得"
     DATA_RESPONSE=$(curl -s -X GET "$BASE_URL/content/$CONTENT_ID/data" \
@@ -282,7 +282,7 @@ if [ -n "$CONTENT_ID" ]; then
     fi
 
     # CRDT履歴の取得（認証ヘッダー付き）
-    generate_signature "$TEST_PRIVATE_KEY" "read" "content"
+    generate_signature "$TEST_PRIVATE_KEY" "read" "$CONTENT_ID"
 
     log_test "CRDT履歴の取得"
     HIST_RESPONSE=$(curl -s -X GET "$BASE_URL/content/$CONTENT_ID/history" \

--- a/monas-state-node/src/application_service/content_sync_service.rs
+++ b/monas-state-node/src/application_service/content_sync_service.rs
@@ -101,13 +101,25 @@ where
             }
         };
 
-        // 2. Get local version to request only newer operations
-        let local_version = self
+        // 2. Get local version to request only newer operations.
+        // Only trust the local history if we actually hold the genesis node:
+        // crsl-lib's `linear_history` returns `[genesis]` even for content we
+        // hold nothing of (phantom history). Passing that as `since` makes
+        // providers skip the Create operation and we would never converge.
+        let has_genesis = self
             .crdt_repo
-            .get_history(genesis_cid)
+            .has_genesis(genesis_cid)
             .await
-            .ok()
-            .and_then(|h| h.last().cloned());
+            .unwrap_or(false);
+        let local_version = if has_genesis {
+            self.crdt_repo
+                .get_history(genesis_cid)
+                .await
+                .ok()
+                .and_then(|h| h.last().cloned())
+        } else {
+            None
+        };
 
         // 3. Fetch operations from each member node
         for node_id in network.member_nodes() {

--- a/monas-state-node/src/application_service/content_sync_service.rs
+++ b/monas-state-node/src/application_service/content_sync_service.rs
@@ -378,6 +378,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_sync_requests_full_history_when_genesis_missing() {
+        // Phantom-history guard: when we do not actually hold the genesis
+        // node, the sync must request the FULL operation history
+        // (since=None). Passing the phantom [genesis] as `since` makes
+        // providers skip the Create operation and the node never converges.
+        let service = create_service_with_members("node-1", "content-1", vec!["node-2"], vec![]);
+        // MockContentRepository is empty -> has_genesis("content-1") == false.
+
+        let _ = service.sync_from_peers("content-1").await.unwrap();
+
+        let since = service.peer_network.fetch_operations_since.lock().await;
+        assert_eq!(since.as_slice(), &[None]);
+    }
+
+    #[tokio::test]
+    async fn test_sync_requests_incremental_when_genesis_present() {
+        let service = create_service_with_members("node-1", "content-1", vec!["node-2"], vec![]);
+        // Materialize the content locally so has_genesis == true.
+        service
+            .crdt_repo
+            .contents
+            .lock()
+            .await
+            .insert("content-1".to_string(), b"data".to_vec());
+        service.crdt_repo.history.lock().await.insert(
+            "content-1".to_string(),
+            vec!["v1".to_string(), "v2".to_string()],
+        );
+
+        let _ = service.sync_from_peers("content-1").await.unwrap();
+
+        let since = service.peer_network.fetch_operations_since.lock().await;
+        assert_eq!(since.as_slice(), &[Some("v2".to_string())]);
+    }
+
+    #[tokio::test]
     async fn test_sync_from_peers_no_network() {
         let service = create_test_service("node-1");
 

--- a/monas-state-node/src/application_service/node.rs
+++ b/monas-state-node/src/application_service/node.rs
@@ -335,7 +335,9 @@ impl StateNode {
             let service_for_relay = self.service.clone();
             let token_relay = token.clone();
             tokio::spawn(async move {
-                use crate::infrastructure::network::libp2p_network::RelayRequestKind;
+                use crate::infrastructure::network::libp2p_network::{
+                    RelayOutcome, RelayRequestKind,
+                };
                 use crate::port::auth_token::AuthToken;
                 tracing::info!("Started relay request handler");
                 loop {
@@ -364,7 +366,7 @@ impl StateNode {
                                             timestamp,
                                         )
                                         .await
-                                        .map(|_| ())
+                                        .map(|_| RelayOutcome::Done)
                                 }
                                 RelayRequestKind::DeleteContent {
                                     content_id,
@@ -381,7 +383,7 @@ impl StateNode {
                                             timestamp,
                                         )
                                         .await
-                                        .map(|_| ())
+                                        .map(|_| RelayOutcome::Done)
                                 }
                                 RelayRequestKind::InvalidateTokens {
                                     content_id,
@@ -398,7 +400,46 @@ impl StateNode {
                                             timestamp,
                                         )
                                         .await
-                                        .map(|_| ())
+                                        .map(|_| RelayOutcome::Done)
+                                }
+                                RelayRequestKind::ReadContent {
+                                    content_id,
+                                    version,
+                                    auth_token,
+                                    request_signature,
+                                    timestamp,
+                                } => {
+                                    let token = AuthToken::new(auth_token);
+                                    service_for_relay
+                                        .read_content_via_relay(
+                                            &content_id,
+                                            version.as_deref(),
+                                            &token,
+                                            Some(&request_signature),
+                                            timestamp,
+                                        )
+                                        .await
+                                        .map(|(data, version)| RelayOutcome::Data {
+                                            data,
+                                            version,
+                                        })
+                                }
+                                RelayRequestKind::ReadHistory {
+                                    content_id,
+                                    auth_token,
+                                    request_signature,
+                                    timestamp,
+                                } => {
+                                    let token = AuthToken::new(auth_token);
+                                    service_for_relay
+                                        .read_history_via_relay(
+                                            &content_id,
+                                            &token,
+                                            Some(&request_signature),
+                                            timestamp,
+                                        )
+                                        .await
+                                        .map(|versions| RelayOutcome::History { versions })
                                 }
                             };
                             let _ = req

--- a/monas-state-node/src/application_service/node.rs
+++ b/monas-state-node/src/application_service/node.rs
@@ -442,9 +442,7 @@ impl StateNode {
                                         .map(|versions| RelayOutcome::History { versions })
                                 }
                             };
-                            let _ = req
-                                .reply
-                                .send(result.map_err(|e| anyhow::anyhow!(e.to_string())));
+                            let _ = req.reply.send(result);
                         }
                     }
                 }

--- a/monas-state-node/src/application_service/state_node_service.rs
+++ b/monas-state-node/src/application_service/state_node_service.rs
@@ -477,75 +477,221 @@ where
         Ok(members)
     }
 
-    /// Ensure the content's CRDT state is available locally, fetching it from
-    /// member nodes if necessary (bug #93, read side).
+    /// Whether this node actually replicates the content (holds its genesis
+    /// node in the local DAG).
     ///
-    /// Read endpoints (data / history / version) read straight from the local
-    /// `crdt_repo`. A node that holds no local state for a content — e.g. a
-    /// client pointed its gateway at a node that is neither the creator nor a
-    /// member — would otherwise 404. This pulls the operations from a member
-    /// (discovered via `resolve_members`) and applies them locally so the
-    /// existing read path works unchanged. Applying the operations also brings
-    /// in the access policy, so the subsequent `verify_read_access` check is
-    /// evaluated against the real policy rather than an empty one.
-    ///
-    /// No-op when we already have local history. Returns `ContentNotFound` if
-    /// no member could supply the operations.
-    ///
-    /// SECURITY NOTE: this reuses the unauthenticated `fetch_operations` RPC,
-    /// so a non-member can pull any content's operations. Acceptable for the
-    /// single-user demo; a hardened version should add a read-relay RPC with
-    /// member-side authorization. Tracked in bug #93 follow-up.
-    pub async fn ensure_content_local(&self, content_id: &str) -> Result<(), StateNodeError> {
-        // Fast path: we already hold this content's genesis node locally.
-        // NOTE: `get_history` cannot be used here — crsl-lib's `linear_history`
-        // returns `[genesis]` even when no node exists (phantom history), which
-        // would make this check always pass and skip the pull.
-        let has_local = self
-            .crdt_repo
+    /// NOTE: `get_history` cannot be used for this — crsl-lib's
+    /// `linear_history` returns `[genesis]` even when no node exists (phantom
+    /// history), which would make such a check always pass.
+    pub async fn has_local_content(&self, content_id: &str) -> bool {
+        self.crdt_repo
             .has_genesis(content_id)
             .await
-            .unwrap_or(false);
-        if has_local {
-            return Ok(());
+            .unwrap_or(false)
+    }
+
+    /// Authorize a read against the content's access policy (bug #93 hardened
+    /// read path).
+    ///
+    /// Authenticates the caller (token + request signature) and grants access
+    /// when the caller is the content owner or the authorization service
+    /// grants `ReadContent`. Content without a policy is readable (it may not
+    /// have a policy yet) — same semantics as the HTTP read path.
+    pub async fn authorize_read(
+        &self,
+        token: &AuthToken,
+        request_signature: Option<&[u8]>,
+        timestamp: Option<u64>,
+        content_id: &str,
+    ) -> Result<(), StateNodeError> {
+        let identity = self
+            .authenticate_for_read(token, request_signature, timestamp)
+            .await?;
+
+        if let Ok(Some(policy)) = self.crdt_repo.get_access_policy(content_id).await {
+            if policy.is_owner(&identity) {
+                return Ok(());
+            }
+
+            let authz_request = crate::port::authorization_service::AuthorizationRequest {
+                identity,
+                resource: ContentId::new(content_id.to_string())?,
+                capability: crate::domain::auth_capability::AuthCapability::ReadContent,
+                token: Some(token.clone()),
+                request_signature: request_signature.map(|s| s.to_vec()),
+            };
+            if let Some(authz_service) = self.authz_service.as_ref() {
+                if let Ok(result) = authz_service.authorize(&authz_request).await {
+                    if result.is_granted() {
+                        return Ok(());
+                    }
+                }
+            }
+
+            return Err(StateNodeError::AuthorizationFailed(
+                "Insufficient permissions: read access required".to_string(),
+            ));
         }
 
-        // Discover the members (local record, or DHT fallback) and pull ops.
-        let members = self.resolve_members(content_id).await?;
-        let content_id_vo = ContentId::new(content_id.to_string())?;
+        // No policy exists yet — allow, matching the HTTP read path.
+        Ok(())
+    }
 
+    /// Serve a relayed data read on a member node (bug #93 hardened read path).
+    ///
+    /// Called by the relay handler when a non-member node forwards a read.
+    /// Re-authenticates the original caller before touching the repository.
+    /// `version: None` serves the latest version. Returns `(data, version)`.
+    pub async fn read_content_via_relay(
+        &self,
+        content_id: &str,
+        version: Option<&str>,
+        token: &AuthToken,
+        request_signature: Option<&[u8]>,
+        timestamp: Option<u64>,
+    ) -> Result<(Vec<u8>, String), StateNodeError> {
+        self.authorize_read(token, request_signature, timestamp, content_id)
+            .await?;
+
+        let content_id_vo = ContentId::new(content_id.to_string())?;
+        match version {
+            Some(v) => {
+                let data = self
+                    .crdt_repo
+                    .get_version(v)
+                    .await
+                    .map_err(|e| StateNodeError::StorageError(e.to_string()))?
+                    .ok_or(StateNodeError::ContentNotFound(content_id_vo))?;
+                Ok((data, v.to_string()))
+            }
+            None => self
+                .crdt_repo
+                .get_latest_with_version(content_id)
+                .await
+                .map_err(|e| StateNodeError::StorageError(e.to_string()))?
+                .ok_or(StateNodeError::ContentNotFound(content_id_vo)),
+        }
+    }
+
+    /// Serve a relayed history read on a member node (bug #93 hardened read
+    /// path). Same authentication contract as `read_content_via_relay`.
+    pub async fn read_history_via_relay(
+        &self,
+        content_id: &str,
+        token: &AuthToken,
+        request_signature: Option<&[u8]>,
+        timestamp: Option<u64>,
+    ) -> Result<Vec<String>, StateNodeError> {
+        self.authorize_read(token, request_signature, timestamp, content_id)
+            .await?;
+
+        // Guard against crsl-lib's phantom `[genesis]` history for content we
+        // don't actually hold.
+        if !self.has_local_content(content_id).await {
+            return Err(StateNodeError::ContentNotFound(ContentId::new(
+                content_id.to_string(),
+            )?));
+        }
+
+        self.crdt_repo
+            .get_history(content_id)
+            .await
+            .map_err(|e| StateNodeError::StorageError(e.to_string()))
+    }
+
+    /// Relay a data read to the content's members (bug #93 hardened read path,
+    /// caller side).
+    ///
+    /// Used by read endpoints on a node that does not replicate the content.
+    /// The caller's auth material is forwarded verbatim so the member can
+    /// re-authenticate; operations are never pulled to this node.
+    pub async fn relay_read_data(
+        &self,
+        content_id: &str,
+        version: Option<&str>,
+        token: &AuthToken,
+        request_signature: Option<&[u8]>,
+        timestamp: Option<u64>,
+    ) -> Result<(Vec<u8>, String), StateNodeError> {
+        let members = self.resolve_members(content_id).await?;
+        let sig: &[u8] = request_signature.unwrap_or(&[]);
+
+        let mut last_err: Option<String> = None;
         for member in &members {
             match self
                 .peer_network
-                .fetch_operations(member, content_id, None)
+                .relay_read_content(member, content_id, version, token.as_str(), sig, timestamp)
                 .await
             {
-                Ok(ops) if !ops.is_empty() => match self.crdt_repo.apply_operations(&ops).await {
-                    Ok(_) => return Ok(()),
-                    Err(e) => {
-                        tracing::warn!(
-                            "ensure_content_local: failed to apply ops from {} for {}: {}",
-                            member,
-                            content_id,
-                            e
-                        );
-                    }
-                },
-                Ok(_) => {
-                    // Member returned no operations; try the next one.
-                }
+                Ok(result) => return Ok(result),
                 Err(e) => {
                     tracing::warn!(
-                        "ensure_content_local: failed to fetch ops from {} for {}: {}",
+                        "relay_read_data: member {} failed for {}: {}",
                         member,
                         content_id,
                         e
                     );
+                    last_err = Some(e.to_string());
                 }
             }
         }
 
-        Err(StateNodeError::ContentNotFound(content_id_vo))
+        Err(Self::map_relay_read_error(content_id, last_err))
+    }
+
+    /// Relay a history read to the content's members (bug #93 hardened read
+    /// path, caller side).
+    pub async fn relay_read_history(
+        &self,
+        content_id: &str,
+        token: &AuthToken,
+        request_signature: Option<&[u8]>,
+        timestamp: Option<u64>,
+    ) -> Result<Vec<String>, StateNodeError> {
+        let members = self.resolve_members(content_id).await?;
+        let sig: &[u8] = request_signature.unwrap_or(&[]);
+
+        let mut last_err: Option<String> = None;
+        for member in &members {
+            match self
+                .peer_network
+                .relay_read_history(member, content_id, token.as_str(), sig, timestamp)
+                .await
+            {
+                Ok(versions) => return Ok(versions),
+                Err(e) => {
+                    tracing::warn!(
+                        "relay_read_history: member {} failed for {}: {}",
+                        member,
+                        content_id,
+                        e
+                    );
+                    last_err = Some(e.to_string());
+                }
+            }
+        }
+
+        Err(Self::map_relay_read_error(content_id, last_err))
+    }
+
+    /// Map the last member error of a relayed read back to a typed error so
+    /// the HTTP layer returns the status the member decided on (the relay
+    /// transport only carries strings).
+    fn map_relay_read_error(content_id: &str, last_err: Option<String>) -> StateNodeError {
+        let msg = last_err.unwrap_or_else(|| "no members responded".to_string());
+        let lower = msg.to_lowercase();
+        if lower.contains("not found") {
+            match ContentId::new(content_id.to_string()) {
+                Ok(cid) => StateNodeError::ContentNotFound(cid),
+                Err(_) => StateNodeError::StorageError(msg),
+            }
+        } else if lower.contains("authentication failed") {
+            StateNodeError::AuthenticationFailed(msg)
+        } else if lower.contains("insufficient permissions") || lower.contains("authorization") {
+            StateNodeError::AuthorizationFailed(msg)
+        } else {
+            StateNodeError::NetworkError(NetworkError::ConnectionFailed(msg))
+        }
     }
 
     /// Register a new node.
@@ -2746,28 +2892,17 @@ mod tests {
         );
     }
 
-    fn sample_operation(genesis_cid: &str) -> crate::port::content_repository::SerializedOperation {
-        crate::port::content_repository::SerializedOperation {
-            data: vec![0x01, 0x02],
-            genesis_cid: genesis_cid.to_string(),
-            author: "node-2".to_string(),
-            timestamp: 1,
-            node_timestamp: 1,
-        }
-    }
-
     #[tokio::test]
-    async fn test_ensure_content_local_pulls_from_discovered_member() {
-        // Bug #93 (read side): a node with no local state for the content must
-        // pull the operations from a DHT-discovered member and apply them
-        // locally so the read endpoints work instead of 404ing.
+    async fn test_relay_read_data_maps_member_not_found() {
+        // Bug #93 (hardened read side): a node with no local state relays the
+        // read to a DHT-discovered member. When every member reports the
+        // content missing, the caller gets a typed ContentNotFound back.
         let node_registry = MockNodeRegistry::new();
         let content_repo = Arc::new(RwLock::new(MockContentNetworkRepository::new()));
         let peer_network = Arc::new(
             MockPeerNetwork::new()
                 .with_local_peer_id("node-1")
-                .with_closest_peers(vec!["node-2".to_string()])
-                .with_fetched_operations(vec![sample_operation("content-1")]),
+                .with_closest_peers(vec!["node-2".to_string()]),
         );
         let event_publisher = MockEventPublisher::new();
         let crdt_repo = Arc::new(MockContentRepository::new());
@@ -2781,18 +2916,31 @@ mod tests {
             "node-1".to_string(),
         );
 
-        let result = service.ensure_content_local("content-1").await;
-        assert!(
-            result.is_ok(),
-            "expected ops pull to succeed, got {result:?}"
-        );
+        let result = service
+            .relay_read_data(
+                "content-1",
+                None,
+                &test_token(),
+                Some(&test_request_signature()),
+                None,
+            )
+            .await;
+        assert!(matches!(result, Err(StateNodeError::ContentNotFound(_))));
     }
 
     #[tokio::test]
-    async fn test_ensure_content_local_errors_when_no_member_has_data() {
-        // No discoverable members → cannot pull → ContentNotFound.
+    async fn test_relay_read_data_errors_when_no_members() {
+        // No discoverable members → nothing to relay to → NoAvailableMembers.
         let service = create_test_service("node-1");
-        let result = service.ensure_content_local("content-1").await;
+        let result = service
+            .relay_read_data(
+                "content-1",
+                None,
+                &test_token(),
+                Some(&test_request_signature()),
+                None,
+            )
+            .await;
         assert!(result.is_err());
         assert!(result
             .unwrap_err()

--- a/monas-state-node/src/application_service/state_node_service.rs
+++ b/monas-state-node/src/application_service/state_node_service.rs
@@ -17,11 +17,12 @@ use crate::port::authentication_service::AuthenticationService;
 use crate::port::authorization_service::{AuthorizationRequest, AuthorizationService};
 use crate::port::content_repository::ContentRepository;
 use crate::port::event_publisher::EventPublisher;
-use crate::port::peer_network::PeerNetwork;
+use crate::port::peer_network::{PeerNetwork, RelayReadError, RelayReadErrorKind};
 use crate::port::persistence::{
     PersistentAccessControlRepository, PersistentContentRepository, PersistentNodeRegistry,
 };
 use anyhow::Result;
+use std::ops::ControlFlow;
 use std::sync::Arc;
 
 /// Result of applying an event.
@@ -508,7 +509,20 @@ where
             .authenticate_for_read(token, request_signature, timestamp)
             .await?;
 
-        if let Ok(Some(policy)) = self.crdt_repo.get_access_policy(content_id).await {
+        // Fail closed: an error loading the policy must deny, not fall through
+        // to the "no policy" allow below.
+        let policy = self
+            .crdt_repo
+            .get_access_policy(content_id)
+            .await
+            .map_err(|e| {
+                StateNodeError::StorageError(format!(
+                    "failed to load access policy for {}: {}",
+                    content_id, e
+                ))
+            })?;
+
+        if let Some(policy) = policy {
             if policy.is_owner(&identity) {
                 return Ok(());
             }
@@ -558,7 +572,7 @@ where
             Some(v) => {
                 let data = self
                     .crdt_repo
-                    .get_version(v)
+                    .get_version(content_id, v)
                     .await
                     .map_err(|e| StateNodeError::StorageError(e.to_string()))?
                     .ok_or(StateNodeError::ContentNotFound(content_id_vo))?;
@@ -616,7 +630,7 @@ where
         let members = self.resolve_members(content_id).await?;
         let sig: &[u8] = request_signature.unwrap_or(&[]);
 
-        let mut last_err: Option<String> = None;
+        let mut best: Option<RelayReadError> = None;
         for member in &members {
             match self
                 .peer_network
@@ -631,12 +645,25 @@ where
                         content_id,
                         e
                     );
-                    last_err = Some(e.to_string());
+                    match Self::record_relay_read_error(&mut best, e) {
+                        // An auth verdict is authoritative — the member DID
+                        // evaluate the request. Do not let a later member's
+                        // transport failure overwrite it.
+                        ControlFlow::Break(final_err) => {
+                            return Err(Self::relay_read_error_to_state_error(
+                                content_id, final_err,
+                            ))
+                        }
+                        ControlFlow::Continue(()) => {}
+                    }
                 }
             }
         }
 
-        Err(Self::map_relay_read_error(content_id, last_err))
+        Err(Self::relay_read_error_to_state_error(
+            content_id,
+            best.unwrap_or_else(|| RelayReadError::other("no members responded")),
+        ))
     }
 
     /// Relay a history read to the content's members (bug #93 hardened read
@@ -651,7 +678,7 @@ where
         let members = self.resolve_members(content_id).await?;
         let sig: &[u8] = request_signature.unwrap_or(&[]);
 
-        let mut last_err: Option<String> = None;
+        let mut best: Option<RelayReadError> = None;
         for member in &members {
             match self
                 .peer_network
@@ -666,31 +693,69 @@ where
                         content_id,
                         e
                     );
-                    last_err = Some(e.to_string());
+                    match Self::record_relay_read_error(&mut best, e) {
+                        ControlFlow::Break(final_err) => {
+                            return Err(Self::relay_read_error_to_state_error(
+                                content_id, final_err,
+                            ))
+                        }
+                        ControlFlow::Continue(()) => {}
+                    }
                 }
             }
         }
 
-        Err(Self::map_relay_read_error(content_id, last_err))
+        Err(Self::relay_read_error_to_state_error(
+            content_id,
+            best.unwrap_or_else(|| RelayReadError::other("no members responded")),
+        ))
     }
 
-    /// Map the last member error of a relayed read back to a typed error so
-    /// the HTTP layer returns the status the member decided on (the relay
-    /// transport only carries strings).
-    fn map_relay_read_error(content_id: &str, last_err: Option<String>) -> StateNodeError {
-        let msg = last_err.unwrap_or_else(|| "no members responded".to_string());
-        let lower = msg.to_lowercase();
-        if lower.contains("not found") {
-            match ContentId::new(content_id.to_string()) {
-                Ok(cid) => StateNodeError::ContentNotFound(cid),
-                Err(_) => StateNodeError::StorageError(msg),
+    /// Fold one member's relayed-read failure into the running best error.
+    ///
+    /// Auth verdicts (401/403) short-circuit the member loop: the member
+    /// evaluated the caller against the real policy, so asking further
+    /// members cannot change the answer. NotFound is kept over transport
+    /// errors but the loop continues — a lagging member may miss a version
+    /// another member can still serve.
+    fn record_relay_read_error(
+        best: &mut Option<RelayReadError>,
+        err: RelayReadError,
+    ) -> ControlFlow<RelayReadError> {
+        match err.kind {
+            RelayReadErrorKind::AuthenticationFailed | RelayReadErrorKind::AuthorizationFailed => {
+                ControlFlow::Break(err)
             }
-        } else if lower.contains("authentication failed") {
-            StateNodeError::AuthenticationFailed(msg)
-        } else if lower.contains("insufficient permissions") || lower.contains("authorization") {
-            StateNodeError::AuthorizationFailed(msg)
-        } else {
-            StateNodeError::NetworkError(NetworkError::ConnectionFailed(msg))
+            RelayReadErrorKind::NotFound => {
+                *best = Some(err);
+                ControlFlow::Continue(())
+            }
+            RelayReadErrorKind::Other => {
+                if best.is_none() {
+                    *best = Some(err);
+                }
+                ControlFlow::Continue(())
+            }
+        }
+    }
+
+    /// Convert a member's typed relayed-read verdict into the service error
+    /// the HTTP layer maps to a status code.
+    fn relay_read_error_to_state_error(content_id: &str, err: RelayReadError) -> StateNodeError {
+        match err.kind {
+            RelayReadErrorKind::NotFound => match ContentId::new(content_id.to_string()) {
+                Ok(cid) => StateNodeError::ContentNotFound(cid),
+                Err(_) => StateNodeError::StorageError(err.message),
+            },
+            RelayReadErrorKind::AuthenticationFailed => {
+                StateNodeError::AuthenticationFailed(err.message)
+            }
+            RelayReadErrorKind::AuthorizationFailed => {
+                StateNodeError::AuthorizationFailed(err.message)
+            }
+            RelayReadErrorKind::Other => {
+                StateNodeError::NetworkError(NetworkError::ConnectionFailed(err.message))
+            }
         }
     }
 
@@ -2926,6 +2991,202 @@ mod tests {
             )
             .await;
         assert!(matches!(result, Err(StateNodeError::ContentNotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn test_relay_read_data_returns_member_payload() {
+        // Happy path: the member serves the read and the payload comes back.
+        let node_registry = MockNodeRegistry::new();
+        let content_repo = Arc::new(RwLock::new(MockContentNetworkRepository::new()));
+        let peer_network = Arc::new(
+            MockPeerNetwork::new()
+                .with_local_peer_id("node-1")
+                .with_closest_peers(vec!["node-2".to_string()])
+                .with_relay_read_data(b"cipher".to_vec(), "v1"),
+        );
+        let event_publisher = MockEventPublisher::new();
+        let crdt_repo = Arc::new(MockContentRepository::new());
+
+        let service: TestService = StateNodeService::new(
+            node_registry,
+            content_repo,
+            peer_network,
+            event_publisher,
+            crdt_repo,
+            "node-1".to_string(),
+        );
+
+        let result = service
+            .relay_read_data(
+                "content-1",
+                None,
+                &test_token(),
+                Some(&test_request_signature()),
+                None,
+            )
+            .await
+            .expect("relayed read should succeed");
+        assert_eq!(result, (b"cipher".to_vec(), "v1".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_relay_read_data_returns_member_auth_verdict() {
+        // A member's 403 verdict must come back typed (not as a generic
+        // network error), so the HTTP layer returns the member's decision.
+        use crate::port::peer_network::{RelayReadError, RelayReadErrorKind};
+        let node_registry = MockNodeRegistry::new();
+        let content_repo = Arc::new(RwLock::new(MockContentNetworkRepository::new()));
+        let peer_network = Arc::new(
+            MockPeerNetwork::new()
+                .with_local_peer_id("node-1")
+                .with_closest_peers(vec!["node-2".to_string(), "node-3".to_string()])
+                .with_relay_read_error(RelayReadError {
+                    kind: RelayReadErrorKind::AuthorizationFailed,
+                    message: "Insufficient permissions: read access required".to_string(),
+                }),
+        );
+        let event_publisher = MockEventPublisher::new();
+        let crdt_repo = Arc::new(MockContentRepository::new());
+
+        let service: TestService = StateNodeService::new(
+            node_registry,
+            content_repo,
+            peer_network,
+            event_publisher,
+            crdt_repo,
+            "node-1".to_string(),
+        );
+
+        let result = service
+            .relay_read_data(
+                "content-1",
+                None,
+                &test_token(),
+                Some(&test_request_signature()),
+                None,
+            )
+            .await;
+        assert!(matches!(
+            result,
+            Err(StateNodeError::AuthorizationFailed(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_authorize_read_allows_owner() {
+        let service = create_test_service("node-1");
+        let owner = Identity::user("test-user".to_string()).unwrap();
+        let policy = crate::domain::access_policy::AccessPolicy::new(
+            ContentId::new("content-1".to_string()).unwrap(),
+            owner,
+        );
+        service
+            .crdt_repo
+            .access_policies
+            .lock()
+            .await
+            .insert("content-1".to_string(), policy);
+
+        let result = service
+            .authorize_read(
+                &test_token(),
+                Some(&test_request_signature()),
+                None,
+                "content-1",
+            )
+            .await;
+        assert!(result.is_ok(), "owner must be allowed: {result:?}");
+    }
+
+    #[tokio::test]
+    async fn test_authorize_read_allows_when_no_policy() {
+        // Documented semantics: content without a policy is readable.
+        let service = create_test_service("node-1");
+        let result = service
+            .authorize_read(
+                &test_token(),
+                Some(&test_request_signature()),
+                None,
+                "content-1",
+            )
+            .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_authorize_read_denies_non_owner_when_authz_denies() {
+        struct DenyAllAuthorizationService;
+        #[async_trait::async_trait]
+        impl AuthorizationService for DenyAllAuthorizationService {
+            async fn authorize(
+                &self,
+                _request: &AuthorizationRequest,
+            ) -> Result<AuthorizationResult> {
+                Ok(AuthorizationResult::Denied {
+                    reason: "no".to_string(),
+                })
+            }
+        }
+
+        let node_registry = MockNodeRegistry::new();
+        let content_repo = Arc::new(RwLock::new(MockContentNetworkRepository::new()));
+        let peer_network = Arc::new(MockPeerNetwork::new().with_local_peer_id("node-1"));
+        let event_publisher = MockEventPublisher::new();
+        let crdt_repo = Arc::new(MockContentRepository::new());
+
+        let service: TestService = StateNodeService::new(
+            node_registry,
+            content_repo,
+            peer_network,
+            event_publisher,
+            crdt_repo,
+            "node-1".to_string(),
+        )
+        .with_authentication_service(TestAuthService)
+        .with_authorization_service(DenyAllAuthorizationService);
+
+        let owner = Identity::user("someone-else".to_string()).unwrap();
+        let policy = crate::domain::access_policy::AccessPolicy::new(
+            ContentId::new("content-1".to_string()).unwrap(),
+            owner,
+        );
+        service
+            .crdt_repo
+            .access_policies
+            .lock()
+            .await
+            .insert("content-1".to_string(), policy);
+
+        let result = service
+            .authorize_read(
+                &test_token(),
+                Some(&test_request_signature()),
+                None,
+                "content-1",
+            )
+            .await;
+        assert!(matches!(
+            result,
+            Err(StateNodeError::AuthorizationFailed(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_authorize_read_fails_closed_on_policy_error() {
+        // A policy-store failure must deny, not fall through to the
+        // "no policy -> allow" branch.
+        let service = create_test_service("node-1");
+        *service.crdt_repo.access_policy_error.lock().await = true;
+
+        let result = service
+            .authorize_read(
+                &test_token(),
+                Some(&test_request_signature()),
+                None,
+                "content-1",
+            )
+            .await;
+        assert!(matches!(result, Err(StateNodeError::StorageError(_))));
     }
 
     #[tokio::test]

--- a/monas-state-node/src/application_service/state_node_service.rs
+++ b/monas-state-node/src/application_service/state_node_service.rs
@@ -222,12 +222,18 @@ where
 
     /// Authenticate a caller for read operations.
     ///
+    /// The request signature is bound to the specific `content_id` (message
+    /// `read:{content_id}:{timestamp}`), so a signature captured by one node
+    /// cannot be replayed to read other content. Mirrors the delete path,
+    /// which already signs over the content id.
+    ///
     /// Returns the authenticated identity on success.
     pub async fn authenticate_for_read(
         &self,
         token: &AuthToken,
         request_signature: Option<&[u8]>,
         timestamp: Option<u64>,
+        content_id: &str,
     ) -> Result<Identity, StateNodeError> {
         let auth_service = self.auth_service.as_ref().ok_or_else(|| {
             StateNodeError::InvalidConfiguration("Authentication not configured".to_string())
@@ -256,7 +262,7 @@ where
             token,
             sig,
             "read",
-            "content",
+            content_id,
             timestamp,
             None,
         )
@@ -506,7 +512,7 @@ where
         content_id: &str,
     ) -> Result<(), StateNodeError> {
         let identity = self
-            .authenticate_for_read(token, request_signature, timestamp)
+            .authenticate_for_read(token, request_signature, timestamp, content_id)
             .await?;
 
         // Fail closed: an error loading the policy must deny, not fall through
@@ -3111,6 +3117,91 @@ mod tests {
             )
             .await;
         assert!(result.is_ok());
+    }
+
+    /// The read request signature must be verified against a message bound to
+    /// the specific content id (`read:{content_id}:{timestamp}`), not a
+    /// generic `read:content:{timestamp}`. This keeps a signature forwarded to
+    /// relay members (or leaked to a non-member node) from being replayed to
+    /// read other content (PR #54 review).
+    #[tokio::test]
+    async fn test_read_signature_message_is_bound_to_content_id() {
+        struct CapturingAuthService {
+            messages: Arc<std::sync::Mutex<Vec<String>>>,
+        }
+
+        #[async_trait::async_trait]
+        impl AuthenticationService for CapturingAuthService {
+            async fn authenticate(
+                &self,
+                token: &AuthToken,
+                _context: Option<&crate::port::auth_token::AuthContext>,
+            ) -> Result<Identity> {
+                Identity::user(token.as_str().to_string())
+                    .map_err(|e| anyhow::anyhow!(e.to_string()))
+            }
+
+            async fn is_valid(&self, token: &AuthToken) -> Result<bool> {
+                Ok(!token.is_empty())
+            }
+
+            async fn verify_request_signature(
+                &self,
+                _token: &AuthToken,
+                _signature: &[u8],
+                message: &str,
+                _timestamp: Option<u64>,
+            ) -> Result<()> {
+                self.messages.lock().unwrap().push(message.to_string());
+                Ok(())
+            }
+
+            async fn verify_jwt_signature(&self, _token: &AuthToken) -> Result<()> {
+                Ok(())
+            }
+
+            async fn get_issuer(&self, token: &AuthToken) -> Result<Option<Identity>> {
+                Ok(Some(
+                    Identity::user(token.as_str().to_string())
+                        .map_err(|e| anyhow::anyhow!(e.to_string()))?,
+                ))
+            }
+        }
+
+        let messages = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let node_registry = MockNodeRegistry::new();
+        let content_repo = Arc::new(RwLock::new(MockContentNetworkRepository::new()));
+        let peer_network = Arc::new(MockPeerNetwork::new().with_local_peer_id("node-1"));
+        let event_publisher = MockEventPublisher::new();
+        let crdt_repo = Arc::new(MockContentRepository::new());
+        let service: TestService = StateNodeService::new(
+            node_registry,
+            content_repo,
+            peer_network,
+            event_publisher,
+            crdt_repo,
+            "node-1".to_string(),
+        )
+        .with_authentication_service(CapturingAuthService {
+            messages: Arc::clone(&messages),
+        });
+
+        service
+            .authenticate_for_read(
+                &test_token(),
+                Some(&test_request_signature()),
+                Some(1234),
+                "content-abc",
+            )
+            .await
+            .expect("authentication should succeed");
+
+        let captured = messages.lock().unwrap();
+        assert_eq!(
+            captured.as_slice(),
+            ["read:content-abc:1234"],
+            "read signature message must include the content id"
+        );
     }
 
     #[tokio::test]

--- a/monas-state-node/src/application_service/state_node_service.rs
+++ b/monas-state-node/src/application_service/state_node_service.rs
@@ -497,12 +497,14 @@ where
     /// single-user demo; a hardened version should add a read-relay RPC with
     /// member-side authorization. Tracked in bug #93 follow-up.
     pub async fn ensure_content_local(&self, content_id: &str) -> Result<(), StateNodeError> {
-        // Fast path: we already hold local history for this content.
+        // Fast path: we already hold this content's genesis node locally.
+        // NOTE: `get_history` cannot be used here — crsl-lib's `linear_history`
+        // returns `[genesis]` even when no node exists (phantom history), which
+        // would make this check always pass and skip the pull.
         let has_local = self
             .crdt_repo
-            .get_history(content_id)
+            .has_genesis(content_id)
             .await
-            .map(|h| !h.is_empty())
             .unwrap_or(false);
         if has_local {
             return Ok(());

--- a/monas-state-node/src/bin/test_auth_generator.rs
+++ b/monas-state-node/src/bin/test_auth_generator.rs
@@ -88,8 +88,8 @@ fn generate_test_auth_data() {
 
     // Machine-readable output for script consumption
     println!("PRIVATE_KEY={}", hex::encode(private_key_bytes));
-    println!("PUBLIC_KEY={}", &public_key_hex);
-    println!("KEY_ID=user:{}", &public_key_hex);
+    println!("PUBLIC_KEY={public_key_hex}");
+    println!("KEY_ID=user:{public_key_hex}");
 }
 
 /// Sign a request with the correct message format.

--- a/monas-state-node/src/infrastructure/auth/ucan_adapter.rs
+++ b/monas-state-node/src/infrastructure/auth/ucan_adapter.rs
@@ -470,7 +470,11 @@ mod tests {
         ) -> Result<Option<(Vec<u8>, String)>> {
             unimplemented!()
         }
-        async fn get_version(&self, _version_cid: &str) -> Result<Option<Vec<u8>>> {
+        async fn get_version(
+            &self,
+            _genesis_cid: &str,
+            _version_cid: &str,
+        ) -> Result<Option<Vec<u8>>> {
             unimplemented!()
         }
         async fn get_history(&self, _genesis_cid: &str) -> Result<Vec<String>> {

--- a/monas-state-node/src/infrastructure/crdt_repository.rs
+++ b/monas-state-node/src/infrastructure/crdt_repository.rs
@@ -214,10 +214,19 @@ impl ContentRepository for CrslCrdtRepository {
         }
     }
 
-    async fn get_version(&self, version_cid: &str) -> Result<Option<Vec<u8>>> {
+    async fn get_version(&self, genesis_cid: &str, version_cid: &str) -> Result<Option<Vec<u8>>> {
+        let genesis = Self::parse_cid(genesis_cid)?;
         let cid = Self::parse_cid(version_cid)?;
 
         let repo = self.repo.lock();
+
+        // Scope the lookup to this content's DAG: read authorization is
+        // granted per content, so serving a version from a different series
+        // would be a cross-content read. Unknown nodes resolve to None.
+        match repo.get_genesis(&cid) {
+            Ok(g) if g == genesis => {}
+            _ => return Ok(None),
+        }
 
         match repo.dag.get_node(&cid) {
             Ok(Some(node)) => Ok(Some(node.payload().data.clone())),
@@ -703,6 +712,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_version_rejects_cross_content_lookup() {
+        // Read authorization is granted per content, so a version CID from a
+        // different series must not be readable through another genesis.
+        let tmp = tempdir().unwrap();
+        let repo = CrslCrdtRepository::open(tmp.path()).unwrap();
+
+        let a = repo
+            .create_content(b"content A", "author", None)
+            .await
+            .unwrap();
+        let b = repo
+            .create_content(b"content B", "author", None)
+            .await
+            .unwrap();
+
+        // Sanity: within the right series the version resolves.
+        assert!(repo
+            .get_version(&a.genesis_cid, &a.version_cid)
+            .await
+            .unwrap()
+            .is_some());
+
+        // Cross-content: B's version through A's genesis must be None.
+        assert!(repo
+            .get_version(&a.genesis_cid, &b.version_cid)
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
     async fn test_get_history() {
         let tmp = tempdir().unwrap();
         let repo = CrslCrdtRepository::open(tmp.path()).unwrap();
@@ -730,7 +770,10 @@ mod tests {
         let data = b"Test content";
         let result = repo.create_content(data, "author", None).await.unwrap();
 
-        let retrieved = repo.get_version(&result.version_cid).await.unwrap();
+        let retrieved = repo
+            .get_version(&result.genesis_cid, &result.version_cid)
+            .await
+            .unwrap();
         assert_eq!(retrieved, Some(data.to_vec()));
     }
 

--- a/monas-state-node/src/infrastructure/gossipsub_publisher.rs
+++ b/monas-state-node/src/infrastructure/gossipsub_publisher.rs
@@ -281,6 +281,29 @@ mod tests {
             Ok(true)
         }
 
+        async fn relay_read_content(
+            &self,
+            _peer_id: &str,
+            content_id: &str,
+            _version: Option<&str>,
+            _auth_token: &str,
+            _request_signature: &[u8],
+            _timestamp: Option<u64>,
+        ) -> Result<(Vec<u8>, String)> {
+            Err(anyhow::anyhow!("Content not found: {}", content_id))
+        }
+
+        async fn relay_read_history(
+            &self,
+            _peer_id: &str,
+            content_id: &str,
+            _auth_token: &str,
+            _request_signature: &[u8],
+            _timestamp: Option<u64>,
+        ) -> Result<Vec<String>> {
+            Err(anyhow::anyhow!("Content not found: {}", content_id))
+        }
+
         async fn connected_peer_count(&self) -> usize {
             0
         }

--- a/monas-state-node/src/infrastructure/gossipsub_publisher.rs
+++ b/monas-state-node/src/infrastructure/gossipsub_publisher.rs
@@ -136,6 +136,7 @@ impl<P: PeerNetwork + 'static> EventPublisher for GossipsubEventPublisher<P> {
 mod tests {
     use super::*;
     use crate::port::content_repository::SerializedOperation;
+    use crate::port::peer_network::{RelayReadError, RelayReadErrorKind};
     use std::collections::HashMap;
 
     /// Mock PeerNetwork for testing.
@@ -289,8 +290,11 @@ mod tests {
             _auth_token: &str,
             _request_signature: &[u8],
             _timestamp: Option<u64>,
-        ) -> Result<(Vec<u8>, String)> {
-            Err(anyhow::anyhow!("Content not found: {}", content_id))
+        ) -> std::result::Result<(Vec<u8>, String), RelayReadError> {
+            Err(RelayReadError {
+                kind: RelayReadErrorKind::NotFound,
+                message: format!("Content not found: {}", content_id),
+            })
         }
 
         async fn relay_read_history(
@@ -300,8 +304,11 @@ mod tests {
             _auth_token: &str,
             _request_signature: &[u8],
             _timestamp: Option<u64>,
-        ) -> Result<Vec<String>> {
-            Err(anyhow::anyhow!("Content not found: {}", content_id))
+        ) -> std::result::Result<Vec<String>, RelayReadError> {
+            Err(RelayReadError {
+                kind: RelayReadErrorKind::NotFound,
+                message: format!("Content not found: {}", content_id),
+            })
         }
 
         async fn connected_peer_count(&self) -> usize {

--- a/monas-state-node/src/infrastructure/network/libp2p_network.rs
+++ b/monas-state-node/src/infrastructure/network/libp2p_network.rs
@@ -15,6 +15,7 @@ use crate::domain::events::Event;
 use crate::infrastructure::disk_capacity;
 use crate::port::content_repository::{ContentRepository, SerializedOperation};
 use crate::port::peer_network::PeerNetwork;
+use crate::port::peer_network::{RelayReadError, RelayReadErrorKind};
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -42,7 +43,8 @@ const PEER_NETWORK_TIMEOUT: Duration = Duration::from_secs(30);
 /// which processes them using StateNodeService.
 pub struct RelayRequest {
     pub kind: RelayRequestKind,
-    pub reply: oneshot::Sender<Result<RelayOutcome>>,
+    pub reply:
+        oneshot::Sender<std::result::Result<RelayOutcome, crate::domain::errors::StateNodeError>>,
 }
 
 /// Result payload of a processed relay request.
@@ -249,7 +251,7 @@ enum SwarmCommand {
         auth_token: String,
         request_signature: Vec<u8>,
         timestamp: Option<u64>,
-        reply: oneshot::Sender<Result<Vec<String>>>,
+        reply: RelayHistoryReply,
     },
     /// Send a response back through a ResponseChannel.
     /// Used by spawned relay tasks to send responses without blocking the swarm loop.
@@ -263,7 +265,24 @@ enum SwarmCommand {
 const PENDING_REQUEST_TTL: Duration = Duration::from_secs(120);
 
 /// Reply payload of a relayed data read: `(data, served_version)`.
-type RelayReadReply = oneshot::Sender<Result<(Vec<u8>, String)>>;
+type RelayReadReply = oneshot::Sender<std::result::Result<(Vec<u8>, String), RelayReadError>>;
+/// Reply payload of a relayed history read.
+type RelayHistoryReply = oneshot::Sender<std::result::Result<Vec<String>, RelayReadError>>;
+
+/// Map a member-side service error to the wire verdict for relayed reads.
+fn relay_read_error_kind(e: &crate::domain::errors::StateNodeError) -> RelayReadErrorKind {
+    use crate::domain::errors::StateNodeError as E;
+    match e {
+        E::ContentNotFound(_) => RelayReadErrorKind::NotFound,
+        E::AuthenticationFailed(_) | E::InvalidUcanToken(_) => {
+            RelayReadErrorKind::AuthenticationFailed
+        }
+        E::AuthorizationFailed(_) | E::PermissionDenied(_) => {
+            RelayReadErrorKind::AuthorizationFailed
+        }
+        _ => RelayReadErrorKind::Other,
+    }
+}
 
 /// Pending requests tracking with TTL support.
 ///
@@ -283,7 +302,7 @@ struct PendingRequests {
     relay_delete_queries: HashMap<OutboundRequestId, oneshot::Sender<Result<bool>>>,
     relay_invalidate_tokens_queries: HashMap<OutboundRequestId, oneshot::Sender<Result<bool>>>,
     relay_read_queries: HashMap<OutboundRequestId, RelayReadReply>,
-    relay_history_queries: HashMap<OutboundRequestId, oneshot::Sender<Result<Vec<String>>>>,
+    relay_history_queries: HashMap<OutboundRequestId, RelayHistoryReply>,
     /// Timestamps for all pending request IDs, used for TTL-based cleanup.
     timestamps: HashMap<u64, tokio::time::Instant>,
 }
@@ -1102,10 +1121,10 @@ impl Libp2pNetwork {
                     let _ = reply.send(Err(anyhow::anyhow!("{}", err_msg)));
                 }
                 if let Some(reply) = pending.relay_read_queries.remove(&request_id) {
-                    let _ = reply.send(Err(anyhow::anyhow!("{}", err_msg)));
+                    let _ = reply.send(Err(RelayReadError::other(&err_msg)));
                 }
                 if let Some(reply) = pending.relay_history_queries.remove(&request_id) {
-                    let _ = reply.send(Err(anyhow::anyhow!("{}", err_msg)));
+                    let _ = reply.send(Err(RelayReadError::other(&err_msg)));
                 }
             }
             _ => {}
@@ -1395,16 +1414,11 @@ impl Libp2pNetwork {
                             Ok(Ok(_)) => ContentResponse::Error {
                                 message: "Unexpected relay outcome for ReadContent".to_string(),
                             },
-                            Ok(Err(e)) => {
-                                let msg = e.to_string();
-                                if msg.to_lowercase().contains("not found") {
-                                    ContentResponse::NotFound { content_id }
-                                } else {
-                                    ContentResponse::Error {
-                                        message: format!("Relay read failed: {}", msg),
-                                    }
-                                }
-                            }
+                            Ok(Err(e)) => ContentResponse::ReadFailed {
+                                content_id,
+                                kind: relay_read_error_kind(&e),
+                                message: e.to_string(),
+                            },
                             Err(_) => ContentResponse::Error {
                                 message: "Relay handler dropped".to_string(),
                             },
@@ -1454,16 +1468,11 @@ impl Libp2pNetwork {
                             Ok(Ok(_)) => ContentResponse::Error {
                                 message: "Unexpected relay outcome for ReadHistory".to_string(),
                             },
-                            Ok(Err(e)) => {
-                                let msg = e.to_string();
-                                if msg.to_lowercase().contains("not found") {
-                                    ContentResponse::NotFound { content_id }
-                                } else {
-                                    ContentResponse::Error {
-                                        message: format!("Relay read failed: {}", msg),
-                                    }
-                                }
-                            }
+                            Ok(Err(e)) => ContentResponse::ReadFailed {
+                                content_id,
+                                kind: relay_read_error_kind(&e),
+                                message: e.to_string(),
+                            },
                             Err(_) => ContentResponse::Error {
                                 message: "Relay handler dropped".to_string(),
                             },
@@ -1819,14 +1828,23 @@ impl Libp2pNetwork {
                 ContentResponse::ContentData { data, version, .. } => {
                     let _ = reply.send(Ok((data, version)));
                 }
+                ContentResponse::ReadFailed { kind, message, .. } => {
+                    let _ = reply.send(Err(RelayReadError { kind, message }));
+                }
                 ContentResponse::NotFound { content_id } => {
-                    let _ = reply.send(Err(anyhow::anyhow!("Content not found: {}", content_id)));
+                    let _ = reply.send(Err(RelayReadError {
+                        kind: RelayReadErrorKind::NotFound,
+                        message: format!("Content not found: {}", content_id),
+                    }));
                 }
                 ContentResponse::Error { message } => {
-                    let _ = reply.send(Err(anyhow::anyhow!("Relay read error: {}", message)));
+                    let _ = reply.send(Err(RelayReadError::other(format!(
+                        "Relay read error: {}",
+                        message
+                    ))));
                 }
                 _ => {
-                    let _ = reply.send(Err(anyhow::anyhow!("Unexpected response type")));
+                    let _ = reply.send(Err(RelayReadError::other("Unexpected response type")));
                 }
             }
             return;
@@ -1838,14 +1856,23 @@ impl Libp2pNetwork {
                 ContentResponse::HistoryData { versions, .. } => {
                     let _ = reply.send(Ok(versions));
                 }
+                ContentResponse::ReadFailed { kind, message, .. } => {
+                    let _ = reply.send(Err(RelayReadError { kind, message }));
+                }
                 ContentResponse::NotFound { content_id } => {
-                    let _ = reply.send(Err(anyhow::anyhow!("Content not found: {}", content_id)));
+                    let _ = reply.send(Err(RelayReadError {
+                        kind: RelayReadErrorKind::NotFound,
+                        message: format!("Content not found: {}", content_id),
+                    }));
                 }
                 ContentResponse::Error { message } => {
-                    let _ = reply.send(Err(anyhow::anyhow!("Relay read error: {}", message)));
+                    let _ = reply.send(Err(RelayReadError::other(format!(
+                        "Relay read error: {}",
+                        message
+                    ))));
                 }
                 _ => {
-                    let _ = reply.send(Err(anyhow::anyhow!("Unexpected response type")));
+                    let _ = reply.send(Err(RelayReadError::other("Unexpected response type")));
                 }
             }
         }
@@ -2401,9 +2428,9 @@ impl PeerNetwork for Libp2pNetwork {
         auth_token: &str,
         request_signature: &[u8],
         timestamp: Option<u64>,
-    ) -> Result<(Vec<u8>, String)> {
+    ) -> std::result::Result<(Vec<u8>, String), RelayReadError> {
         let peer_id = PeerId::from_str(peer_id)
-            .map_err(|_| anyhow::anyhow!("Invalid peer ID: {}", peer_id))?;
+            .map_err(|_| RelayReadError::other(format!("Invalid peer ID: {}", peer_id)))?;
 
         let (tx, rx) = oneshot::channel();
         self.command_tx
@@ -2417,12 +2444,12 @@ impl PeerNetwork for Libp2pNetwork {
                 reply: tx,
             })
             .await
-            .map_err(|_| anyhow::anyhow!("Failed to send command"))?;
+            .map_err(|_| RelayReadError::other("Failed to send command"))?;
 
         tokio::time::timeout(PEER_NETWORK_TIMEOUT, rx)
             .await
-            .map_err(|_| anyhow::anyhow!("relay_read_content timed out"))?
-            .map_err(|_| anyhow::anyhow!("Failed to receive response"))?
+            .map_err(|_| RelayReadError::other("relay_read_content timed out"))?
+            .map_err(|_| RelayReadError::other("Failed to receive response"))?
     }
 
     async fn relay_read_history(
@@ -2432,9 +2459,9 @@ impl PeerNetwork for Libp2pNetwork {
         auth_token: &str,
         request_signature: &[u8],
         timestamp: Option<u64>,
-    ) -> Result<Vec<String>> {
+    ) -> std::result::Result<Vec<String>, RelayReadError> {
         let peer_id = PeerId::from_str(peer_id)
-            .map_err(|_| anyhow::anyhow!("Invalid peer ID: {}", peer_id))?;
+            .map_err(|_| RelayReadError::other(format!("Invalid peer ID: {}", peer_id)))?;
 
         let (tx, rx) = oneshot::channel();
         self.command_tx
@@ -2447,12 +2474,12 @@ impl PeerNetwork for Libp2pNetwork {
                 reply: tx,
             })
             .await
-            .map_err(|_| anyhow::anyhow!("Failed to send command"))?;
+            .map_err(|_| RelayReadError::other("Failed to send command"))?;
 
         tokio::time::timeout(PEER_NETWORK_TIMEOUT, rx)
             .await
-            .map_err(|_| anyhow::anyhow!("relay_read_history timed out"))?
-            .map_err(|_| anyhow::anyhow!("Failed to receive response"))?
+            .map_err(|_| RelayReadError::other("relay_read_history timed out"))?
+            .map_err(|_| RelayReadError::other("Failed to receive response"))?
     }
 
     async fn connected_peer_count(&self) -> usize {

--- a/monas-state-node/src/infrastructure/network/libp2p_network.rs
+++ b/monas-state-node/src/infrastructure/network/libp2p_network.rs
@@ -42,7 +42,17 @@ const PEER_NETWORK_TIMEOUT: Duration = Duration::from_secs(30);
 /// which processes them using StateNodeService.
 pub struct RelayRequest {
     pub kind: RelayRequestKind,
-    pub reply: oneshot::Sender<Result<()>>,
+    pub reply: oneshot::Sender<Result<RelayOutcome>>,
+}
+
+/// Result payload of a processed relay request.
+pub enum RelayOutcome {
+    /// Write relays (update/delete/invalidate) complete without a payload.
+    Done,
+    /// Relayed data read: raw bytes plus the version that was served.
+    Data { data: Vec<u8>, version: String },
+    /// Relayed history read.
+    History { versions: Vec<String> },
 }
 
 /// The kind of relay request.
@@ -61,6 +71,20 @@ pub enum RelayRequestKind {
         timestamp: Option<u64>,
     },
     InvalidateTokens {
+        content_id: String,
+        auth_token: String,
+        request_signature: Vec<u8>,
+        timestamp: Option<u64>,
+    },
+    ReadContent {
+        content_id: String,
+        /// `None` reads the latest version; `Some(v)` a specific version CID.
+        version: Option<String>,
+        auth_token: String,
+        request_signature: Vec<u8>,
+        timestamp: Option<u64>,
+    },
+    ReadHistory {
         content_id: String,
         auth_token: String,
         request_signature: Vec<u8>,
@@ -210,6 +234,23 @@ enum SwarmCommand {
         timestamp: Option<u64>,
         reply: oneshot::Sender<Result<bool>>,
     },
+    RelayReadContent {
+        peer_id: PeerId,
+        content_id: String,
+        version: Option<String>,
+        auth_token: String,
+        request_signature: Vec<u8>,
+        timestamp: Option<u64>,
+        reply: oneshot::Sender<Result<(Vec<u8>, String)>>,
+    },
+    RelayReadHistory {
+        peer_id: PeerId,
+        content_id: String,
+        auth_token: String,
+        request_signature: Vec<u8>,
+        timestamp: Option<u64>,
+        reply: oneshot::Sender<Result<Vec<String>>>,
+    },
     /// Send a response back through a ResponseChannel.
     /// Used by spawned relay tasks to send responses without blocking the swarm loop.
     SendRelayResponse {
@@ -238,6 +279,8 @@ struct PendingRequests {
     relay_update_queries: HashMap<OutboundRequestId, oneshot::Sender<Result<bool>>>,
     relay_delete_queries: HashMap<OutboundRequestId, oneshot::Sender<Result<bool>>>,
     relay_invalidate_tokens_queries: HashMap<OutboundRequestId, oneshot::Sender<Result<bool>>>,
+    relay_read_queries: HashMap<OutboundRequestId, oneshot::Sender<Result<(Vec<u8>, String)>>>,
+    relay_history_queries: HashMap<OutboundRequestId, oneshot::Sender<Result<Vec<String>>>>,
     /// Timestamps for all pending request IDs, used for TTL-based cleanup.
     timestamps: HashMap<u64, tokio::time::Instant>,
 }
@@ -261,6 +304,8 @@ impl PendingRequests {
         self.relay_delete_queries.retain(|_, s| !s.is_closed());
         self.relay_invalidate_tokens_queries
             .retain(|_, s| !s.is_closed());
+        self.relay_read_queries.retain(|_, s| !s.is_closed());
+        self.relay_history_queries.retain(|_, s| !s.is_closed());
 
         // Clean up expired timestamps
         self.timestamps
@@ -756,6 +801,46 @@ impl Libp2pNetwork {
                     .relay_invalidate_tokens_queries
                     .insert(request_id, reply);
             }
+            SwarmCommand::RelayReadContent {
+                peer_id,
+                content_id,
+                version,
+                auth_token,
+                request_signature,
+                timestamp,
+                reply,
+            } => {
+                let request_id = swarm.behaviour_mut().request_response.send_request(
+                    &peer_id,
+                    ContentRequest::ReadContent {
+                        content_id,
+                        version,
+                        auth_token,
+                        request_signature,
+                        timestamp,
+                    },
+                );
+                pending.relay_read_queries.insert(request_id, reply);
+            }
+            SwarmCommand::RelayReadHistory {
+                peer_id,
+                content_id,
+                auth_token,
+                request_signature,
+                timestamp,
+                reply,
+            } => {
+                let request_id = swarm.behaviour_mut().request_response.send_request(
+                    &peer_id,
+                    ContentRequest::ReadHistory {
+                        content_id,
+                        auth_token,
+                        request_signature,
+                        timestamp,
+                    },
+                );
+                pending.relay_history_queries.insert(request_id, reply);
+            }
             SwarmCommand::SendRelayResponse { channel, response } => {
                 if let Err(e) = swarm
                     .behaviour_mut()
@@ -1013,6 +1098,12 @@ impl Libp2pNetwork {
                 if let Some(reply) = pending.relay_invalidate_tokens_queries.remove(&request_id) {
                     let _ = reply.send(Err(anyhow::anyhow!("{}", err_msg)));
                 }
+                if let Some(reply) = pending.relay_read_queries.remove(&request_id) {
+                    let _ = reply.send(Err(anyhow::anyhow!("{}", err_msg)));
+                }
+                if let Some(reply) = pending.relay_history_queries.remove(&request_id) {
+                    let _ = reply.send(Err(anyhow::anyhow!("{}", err_msg)));
+                }
             }
             _ => {}
         }
@@ -1148,7 +1239,7 @@ impl Libp2pNetwork {
                     };
                     let response = if channels.relay_tx.send(relay_req).await.is_ok() {
                         match reply_rx.await {
-                            Ok(Ok(())) => ContentResponse::UpdateResult {
+                            Ok(Ok(_)) => ContentResponse::UpdateResult {
                                 content_id,
                                 success: true,
                             },
@@ -1195,7 +1286,7 @@ impl Libp2pNetwork {
                     };
                     let response = if channels.relay_tx.send(relay_req).await.is_ok() {
                         match reply_rx.await {
-                            Ok(Ok(())) => ContentResponse::DeleteResult {
+                            Ok(Ok(_)) => ContentResponse::DeleteResult {
                                 content_id,
                                 success: true,
                             },
@@ -1242,13 +1333,134 @@ impl Libp2pNetwork {
                     };
                     let response = if channels.relay_tx.send(relay_req).await.is_ok() {
                         match reply_rx.await {
-                            Ok(Ok(())) => ContentResponse::InvalidateTokensResult {
+                            Ok(Ok(_)) => ContentResponse::InvalidateTokensResult {
                                 content_id,
                                 success: true,
                             },
                             Ok(Err(e)) => ContentResponse::Error {
                                 message: format!("Relay invalidate_tokens failed: {}", e),
                             },
+                            Err(_) => ContentResponse::Error {
+                                message: "Relay handler dropped".to_string(),
+                            },
+                        }
+                    } else {
+                        ContentResponse::Error {
+                            message: "Relay channel closed".to_string(),
+                        }
+                    };
+                    let _ = channels
+                        .command_tx
+                        .send(SwarmCommand::SendRelayResponse { channel, response })
+                        .await;
+                });
+                return;
+            }
+            ContentRequest::ReadContent {
+                content_id,
+                version,
+                auth_token,
+                request_signature,
+                timestamp,
+            } => {
+                info!(
+                    "Received relayed ReadContent for {} from {}",
+                    content_id, peer
+                );
+                let channels = relay_channels.clone();
+                tokio::spawn(async move {
+                    let (reply_tx, reply_rx) = oneshot::channel();
+                    let relay_req = RelayRequest {
+                        kind: RelayRequestKind::ReadContent {
+                            content_id: content_id.clone(),
+                            version,
+                            auth_token,
+                            request_signature,
+                            timestamp,
+                        },
+                        reply: reply_tx,
+                    };
+                    let response = if channels.relay_tx.send(relay_req).await.is_ok() {
+                        match reply_rx.await {
+                            Ok(Ok(RelayOutcome::Data { data, version })) => {
+                                ContentResponse::ContentData {
+                                    content_id,
+                                    data,
+                                    version,
+                                }
+                            }
+                            Ok(Ok(_)) => ContentResponse::Error {
+                                message: "Unexpected relay outcome for ReadContent".to_string(),
+                            },
+                            Ok(Err(e)) => {
+                                let msg = e.to_string();
+                                if msg.to_lowercase().contains("not found") {
+                                    ContentResponse::NotFound { content_id }
+                                } else {
+                                    ContentResponse::Error {
+                                        message: format!("Relay read failed: {}", msg),
+                                    }
+                                }
+                            }
+                            Err(_) => ContentResponse::Error {
+                                message: "Relay handler dropped".to_string(),
+                            },
+                        }
+                    } else {
+                        ContentResponse::Error {
+                            message: "Relay channel closed".to_string(),
+                        }
+                    };
+                    let _ = channels
+                        .command_tx
+                        .send(SwarmCommand::SendRelayResponse { channel, response })
+                        .await;
+                });
+                return;
+            }
+            ContentRequest::ReadHistory {
+                content_id,
+                auth_token,
+                request_signature,
+                timestamp,
+            } => {
+                info!(
+                    "Received relayed ReadHistory for {} from {}",
+                    content_id, peer
+                );
+                let channels = relay_channels.clone();
+                tokio::spawn(async move {
+                    let (reply_tx, reply_rx) = oneshot::channel();
+                    let relay_req = RelayRequest {
+                        kind: RelayRequestKind::ReadHistory {
+                            content_id: content_id.clone(),
+                            auth_token,
+                            request_signature,
+                            timestamp,
+                        },
+                        reply: reply_tx,
+                    };
+                    let response = if channels.relay_tx.send(relay_req).await.is_ok() {
+                        match reply_rx.await {
+                            Ok(Ok(RelayOutcome::History { versions })) => {
+                                ContentResponse::HistoryData {
+                                    content_id,
+                                    versions,
+                                }
+                            }
+                            Ok(Ok(_)) => ContentResponse::Error {
+                                message: "Unexpected relay outcome for ReadHistory".to_string(),
+                            },
+                            Ok(Err(e)) => {
+                                let msg = e.to_string();
+                                if msg.to_lowercase().contains("not found") {
+                                    ContentResponse::NotFound { content_id }
+                                } else {
+                                    ContentResponse::Error {
+                                        message: format!("Relay read failed: {}", msg),
+                                    }
+                                }
+                            }
                             Err(_) => ContentResponse::Error {
                                 message: "Relay handler dropped".to_string(),
                             },
@@ -1447,7 +1659,9 @@ impl Libp2pNetwork {
             // Relay variants already handled above and returned early
             ContentRequest::UpdateContent { .. }
             | ContentRequest::DeleteContent { .. }
-            | ContentRequest::InvalidateTokens { .. } => unreachable!(),
+            | ContentRequest::InvalidateTokens { .. }
+            | ContentRequest::ReadContent { .. }
+            | ContentRequest::ReadHistory { .. } => unreachable!(),
         };
 
         if let Err(e) = swarm
@@ -1588,6 +1802,44 @@ impl Libp2pNetwork {
                         "Relay invalidate_tokens error: {}",
                         message
                     )));
+                }
+                _ => {
+                    let _ = reply.send(Err(anyhow::anyhow!("Unexpected response type")));
+                }
+            }
+            return;
+        }
+
+        // Handle relay read (data) response
+        if let Some(reply) = pending.relay_read_queries.remove(&request_id) {
+            match response {
+                ContentResponse::ContentData { data, version, .. } => {
+                    let _ = reply.send(Ok((data, version)));
+                }
+                ContentResponse::NotFound { content_id } => {
+                    let _ = reply.send(Err(anyhow::anyhow!("Content not found: {}", content_id)));
+                }
+                ContentResponse::Error { message } => {
+                    let _ = reply.send(Err(anyhow::anyhow!("Relay read error: {}", message)));
+                }
+                _ => {
+                    let _ = reply.send(Err(anyhow::anyhow!("Unexpected response type")));
+                }
+            }
+            return;
+        }
+
+        // Handle relay read (history) response
+        if let Some(reply) = pending.relay_history_queries.remove(&request_id) {
+            match response {
+                ContentResponse::HistoryData { versions, .. } => {
+                    let _ = reply.send(Ok(versions));
+                }
+                ContentResponse::NotFound { content_id } => {
+                    let _ = reply.send(Err(anyhow::anyhow!("Content not found: {}", content_id)));
+                }
+                ContentResponse::Error { message } => {
+                    let _ = reply.send(Err(anyhow::anyhow!("Relay read error: {}", message)));
                 }
                 _ => {
                     let _ = reply.send(Err(anyhow::anyhow!("Unexpected response type")));
@@ -2135,6 +2387,68 @@ impl PeerNetwork for Libp2pNetwork {
         tokio::time::timeout(PEER_NETWORK_TIMEOUT, rx)
             .await
             .map_err(|_| anyhow::anyhow!("relay_invalidate_tokens timed out"))?
+            .map_err(|_| anyhow::anyhow!("Failed to receive response"))?
+    }
+
+    async fn relay_read_content(
+        &self,
+        peer_id: &str,
+        content_id: &str,
+        version: Option<&str>,
+        auth_token: &str,
+        request_signature: &[u8],
+        timestamp: Option<u64>,
+    ) -> Result<(Vec<u8>, String)> {
+        let peer_id = PeerId::from_str(peer_id)
+            .map_err(|_| anyhow::anyhow!("Invalid peer ID: {}", peer_id))?;
+
+        let (tx, rx) = oneshot::channel();
+        self.command_tx
+            .send(SwarmCommand::RelayReadContent {
+                peer_id,
+                content_id: content_id.to_string(),
+                version: version.map(ToOwned::to_owned),
+                auth_token: auth_token.to_string(),
+                request_signature: request_signature.to_vec(),
+                timestamp,
+                reply: tx,
+            })
+            .await
+            .map_err(|_| anyhow::anyhow!("Failed to send command"))?;
+
+        tokio::time::timeout(PEER_NETWORK_TIMEOUT, rx)
+            .await
+            .map_err(|_| anyhow::anyhow!("relay_read_content timed out"))?
+            .map_err(|_| anyhow::anyhow!("Failed to receive response"))?
+    }
+
+    async fn relay_read_history(
+        &self,
+        peer_id: &str,
+        content_id: &str,
+        auth_token: &str,
+        request_signature: &[u8],
+        timestamp: Option<u64>,
+    ) -> Result<Vec<String>> {
+        let peer_id = PeerId::from_str(peer_id)
+            .map_err(|_| anyhow::anyhow!("Invalid peer ID: {}", peer_id))?;
+
+        let (tx, rx) = oneshot::channel();
+        self.command_tx
+            .send(SwarmCommand::RelayReadHistory {
+                peer_id,
+                content_id: content_id.to_string(),
+                auth_token: auth_token.to_string(),
+                request_signature: request_signature.to_vec(),
+                timestamp,
+                reply: tx,
+            })
+            .await
+            .map_err(|_| anyhow::anyhow!("Failed to send command"))?;
+
+        tokio::time::timeout(PEER_NETWORK_TIMEOUT, rx)
+            .await
+            .map_err(|_| anyhow::anyhow!("relay_read_history timed out"))?
             .map_err(|_| anyhow::anyhow!("Failed to receive response"))?
     }
 

--- a/monas-state-node/src/infrastructure/network/libp2p_network.rs
+++ b/monas-state-node/src/infrastructure/network/libp2p_network.rs
@@ -241,7 +241,7 @@ enum SwarmCommand {
         auth_token: String,
         request_signature: Vec<u8>,
         timestamp: Option<u64>,
-        reply: oneshot::Sender<Result<(Vec<u8>, String)>>,
+        reply: RelayReadReply,
     },
     RelayReadHistory {
         peer_id: PeerId,
@@ -262,6 +262,9 @@ enum SwarmCommand {
 /// TTL for pending requests. Entries older than this are cleaned up to prevent memory leaks.
 const PENDING_REQUEST_TTL: Duration = Duration::from_secs(120);
 
+/// Reply payload of a relayed data read: `(data, served_version)`.
+type RelayReadReply = oneshot::Sender<Result<(Vec<u8>, String)>>;
+
 /// Pending requests tracking with TTL support.
 ///
 /// Each request tracks its creation time. A periodic sweep removes entries
@@ -279,7 +282,7 @@ struct PendingRequests {
     relay_update_queries: HashMap<OutboundRequestId, oneshot::Sender<Result<bool>>>,
     relay_delete_queries: HashMap<OutboundRequestId, oneshot::Sender<Result<bool>>>,
     relay_invalidate_tokens_queries: HashMap<OutboundRequestId, oneshot::Sender<Result<bool>>>,
-    relay_read_queries: HashMap<OutboundRequestId, oneshot::Sender<Result<(Vec<u8>, String)>>>,
+    relay_read_queries: HashMap<OutboundRequestId, RelayReadReply>,
     relay_history_queries: HashMap<OutboundRequestId, oneshot::Sender<Result<Vec<String>>>>,
     /// Timestamps for all pending request IDs, used for TTL-based cleanup.
     timestamps: HashMap<u64, tokio::time::Instant>,

--- a/monas-state-node/src/infrastructure/network/protocol.rs
+++ b/monas-state-node/src/infrastructure/network/protocol.rs
@@ -66,6 +66,30 @@ pub enum ContentRequest {
         request_signature: Vec<u8>,
         timestamp: Option<u64>,
     },
+    /// Relay a content-data read to a member node.
+    ///
+    /// Sent by a node that does not replicate the content (e.g. the
+    /// gateway-facing node) so a member can serve the read. The member
+    /// re-authenticates the original caller from `auth_token` /
+    /// `request_signature` and enforces the content's access policy before
+    /// returning any data.
+    ReadContent {
+        content_id: String,
+        /// `None` reads the latest version; `Some(v)` a specific version CID.
+        version: Option<String>,
+        auth_token: String,
+        request_signature: Vec<u8>,
+        timestamp: Option<u64>,
+    },
+    /// Relay a version-history read to a member node.
+    ///
+    /// Same authentication contract as [`ContentRequest::ReadContent`].
+    ReadHistory {
+        content_id: String,
+        auth_token: String,
+        request_signature: Vec<u8>,
+        timestamp: Option<u64>,
+    },
 }
 
 /// Response types for the content protocol.
@@ -101,6 +125,11 @@ pub enum ContentResponse {
     DeleteResult { content_id: String, success: bool },
     /// Response to relayed invalidate_tokens request.
     InvalidateTokensResult { content_id: String, success: bool },
+    /// Response to a relayed history read.
+    HistoryData {
+        content_id: String,
+        versions: Vec<String>,
+    },
     /// Content not found.
     NotFound { content_id: String },
     /// Error response.

--- a/monas-state-node/src/infrastructure/network/protocol.rs
+++ b/monas-state-node/src/infrastructure/network/protocol.rs
@@ -6,7 +6,7 @@
 
 use serde::{Deserialize, Serialize};
 
-pub use crate::port::peer_network::PushBootstrap;
+pub use crate::port::peer_network::{PushBootstrap, RelayReadErrorKind};
 
 /// Protocol name for capacity queries.
 pub const CAPACITY_PROTOCOL: &str = "/monas/capacity/1.0.0";
@@ -129,6 +129,14 @@ pub enum ContentResponse {
     HistoryData {
         content_id: String,
         versions: Vec<String>,
+    },
+    /// Failure of a relayed read, carrying the member's typed verdict so the
+    /// relaying node can map it back to 401/403/404 without parsing message
+    /// text.
+    ReadFailed {
+        content_id: String,
+        kind: RelayReadErrorKind,
+        message: String,
     },
     /// Content not found.
     NotFound { content_id: String },

--- a/monas-state-node/src/infrastructure/persistence/sled_public_key_repository.rs
+++ b/monas-state-node/src/infrastructure/persistence/sled_public_key_repository.rs
@@ -302,9 +302,20 @@ mod tests {
             repo.flush().await.unwrap();
         }
 
-        // Open new repository instance and verify key persists
+        // Open new repository instance and verify key persists.
+        // sled releases its file lock asynchronously on Drop, so an immediate
+        // reopen can transiently fail with WouldBlock on slow CI runners —
+        // retry briefly instead of failing the test on that race.
         {
-            let repo = SledPublicKeyRepository::open(temp_dir.path()).unwrap();
+            let mut repo = SledPublicKeyRepository::open(temp_dir.path());
+            for _ in 0..20 {
+                if repo.is_ok() {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                repo = SledPublicKeyRepository::open(temp_dir.path());
+            }
+            let repo = repo.unwrap();
             let retrieved = repo.get_public_key(&node_id).await.unwrap();
             assert!(retrieved.is_some());
             assert_eq!(retrieved.unwrap(), public_key);

--- a/monas-state-node/src/port/content_repository.rs
+++ b/monas-state-node/src/port/content_repository.rs
@@ -109,14 +109,19 @@ pub trait ContentRepository: Send + Sync {
     async fn get_latest_with_version(&self, genesis_cid: &str)
         -> Result<Option<(Vec<u8>, String)>>;
 
-    /// Get content at a specific version.
+    /// Get content at a specific version, scoped to one content series.
     ///
     /// # Arguments
+    /// * `genesis_cid` - The genesis CID of the content the caller is
+    ///   authorized for. The version MUST belong to this series — a raw CID
+    ///   lookup would let a caller authorized for one content read any other
+    ///   content's versions.
     /// * `version_cid` - The specific version CID
     ///
     /// # Returns
-    /// The content data at that version, or None if not found.
-    async fn get_version(&self, version_cid: &str) -> Result<Option<Vec<u8>>>;
+    /// The content data at that version, or None if the version does not
+    /// exist or belongs to a different content series.
+    async fn get_version(&self, genesis_cid: &str, version_cid: &str) -> Result<Option<Vec<u8>>>;
 
     /// Get the version history of content.
     ///

--- a/monas-state-node/src/port/peer_network.rs
+++ b/monas-state-node/src/port/peer_network.rs
@@ -28,6 +28,43 @@ pub struct PushBootstrap {
     pub created_at: u64,
 }
 
+/// Machine-readable failure category of a relayed read, decided by the
+/// responding member.
+///
+/// Crosses the wire inside `ContentResponse::ReadFailed` so the relaying
+/// node can return the member's verdict (401/403/404) as a typed error
+/// instead of re-deriving it from error-message text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RelayReadErrorKind {
+    /// The member does not hold the content/version (404).
+    NotFound,
+    /// The member could not authenticate the forwarded caller (401).
+    AuthenticationFailed,
+    /// The member authenticated the caller but denied read access (403).
+    AuthorizationFailed,
+    /// Transport failures, timeouts, or unclassified member errors. Unlike
+    /// the verdict kinds above, this does not represent a member decision.
+    Other,
+}
+
+/// Failure of a relayed read: the member's verdict (`kind`) plus its
+/// human-readable message.
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("{message}")]
+pub struct RelayReadError {
+    pub kind: RelayReadErrorKind,
+    pub message: String,
+}
+
+impl RelayReadError {
+    pub fn other(message: impl Into<String>) -> Self {
+        Self {
+            kind: RelayReadErrorKind::Other,
+            message: message.into(),
+        }
+    }
+}
+
 /// Abstract interface for peer-to-peer network operations.
 ///
 /// This trait provides methods for:
@@ -185,7 +222,7 @@ pub trait PeerNetwork: Send + Sync {
         auth_token: &str,
         request_signature: &[u8],
         timestamp: Option<u64>,
-    ) -> Result<(Vec<u8>, String)>;
+    ) -> std::result::Result<(Vec<u8>, String), RelayReadError>;
 
     /// Relay a version-history read to a member node.
     ///
@@ -197,7 +234,7 @@ pub trait PeerNetwork: Send + Sync {
         auth_token: &str,
         request_signature: &[u8],
         timestamp: Option<u64>,
-    ) -> Result<Vec<String>>;
+    ) -> std::result::Result<Vec<String>, RelayReadError>;
 
     // ========== Monitoring Methods ==========
 

--- a/monas-state-node/src/port/peer_network.rs
+++ b/monas-state-node/src/port/peer_network.rs
@@ -171,6 +171,34 @@ pub trait PeerNetwork: Send + Sync {
         timestamp: Option<u64>,
     ) -> Result<bool>;
 
+    /// Relay a content-data read to a member node.
+    ///
+    /// Used when a node that does not replicate the content receives a read
+    /// request. The member re-authenticates the original caller (token +
+    /// request signature) and enforces the access policy before serving.
+    /// `version: None` reads the latest version. Returns `(data, version)`.
+    async fn relay_read_content(
+        &self,
+        peer_id: &str,
+        content_id: &str,
+        version: Option<&str>,
+        auth_token: &str,
+        request_signature: &[u8],
+        timestamp: Option<u64>,
+    ) -> Result<(Vec<u8>, String)>;
+
+    /// Relay a version-history read to a member node.
+    ///
+    /// Same authentication contract as [`PeerNetwork::relay_read_content`].
+    async fn relay_read_history(
+        &self,
+        peer_id: &str,
+        content_id: &str,
+        auth_token: &str,
+        request_signature: &[u8],
+        timestamp: Option<u64>,
+    ) -> Result<Vec<String>>;
+
     // ========== Monitoring Methods ==========
 
     /// Get the number of currently connected peers.

--- a/monas-state-node/src/presentation/http_api.rs
+++ b/monas-state-node/src/presentation/http_api.rs
@@ -719,7 +719,7 @@ async fn get_content_data(
 
     // Get data based on version parameter
     let data_result = if let Some(version) = &query.version {
-        crdt_repo.get_version(version).await
+        crdt_repo.get_version(&content_id, version).await
     } else {
         crdt_repo.get_latest(&content_id).await
     };
@@ -811,7 +811,7 @@ async fn get_content_version(
 
     let crdt_repo = state.crdt_repo();
 
-    match crdt_repo.get_version(&version).await {
+    match crdt_repo.get_version(&content_id, &version).await {
         Ok(Some(data)) => {
             let encoded = base64::engine::general_purpose::STANDARD.encode(&data);
             Json(ContentDataResponse {

--- a/monas-state-node/src/presentation/http_api.rs
+++ b/monas-state-node/src/presentation/http_api.rs
@@ -613,66 +613,84 @@ async fn verify_read_access(
     let request_sig = extract_request_signature(headers);
     let timestamp = extract_request_timestamp(headers);
 
-    // Authenticate the caller
-    let identity = state
-        .authenticate_for_read(&token, request_sig.as_deref(), timestamp)
+    state
+        .authorize_read(&token, request_sig.as_deref(), timestamp, content_id)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::UNAUTHORIZED,
-                Json(ErrorResponse {
-                    error: format!("Authentication failed: {}", e),
-                }),
-            )
-                .into_response()
-        })?;
+        .map_err(|e| e.into_response())
+}
 
-    // Check access policy for read permission
-    let crdt_repo = state.crdt_repo();
-    if let Ok(Some(policy)) = crdt_repo.get_access_policy(content_id).await {
-        // Owner always has access
-        if policy.is_owner(&identity) {
-            return Ok(());
-        }
-
-        // Non-owner: needs AuthToken-based authorization
-        // The Bearer token is used as-is for JWT-based auth
-        let request_signature = extract_request_signature(headers);
-        let authz_request = crate::port::authorization_service::AuthorizationRequest {
-            identity,
-            resource: crate::domain::value_objects::ContentId::new(content_id.to_string())
-                .map_err(|_| {
-                    (
-                        StatusCode::BAD_REQUEST,
-                        Json(ErrorResponse {
-                            error: "Invalid content ID".to_string(),
-                        }),
-                    )
-                        .into_response()
-                })?,
-            capability: crate::domain::auth_capability::AuthCapability::ReadContent,
-            token: Some(token),
-            request_signature,
-        };
-
-        if let Some(authz_service) = state.authz_service() {
-            match authz_service.authorize(&authz_request).await {
-                Ok(result) if result.is_granted() => return Ok(()),
-                _ => {}
-            }
-        }
-
-        return Err((
-            StatusCode::FORBIDDEN,
+/// Serve a read for content this node does not replicate by relaying it —
+/// auth material included — to a member node (bug #93 hardened read path).
+async fn relay_read_data_response(
+    state: &AppState,
+    headers: &HeaderMap,
+    content_id: &str,
+    version: Option<&str>,
+) -> Response {
+    let Some(token) = extract_auth_token(headers) else {
+        return (
+            StatusCode::UNAUTHORIZED,
             Json(ErrorResponse {
-                error: "Insufficient permissions: read access required".to_string(),
+                error: "Authorization header is required".to_string(),
             }),
         )
-            .into_response());
-    }
-    // If no policy exists, allow access (content may not have a policy yet)
+            .into_response();
+    };
+    let request_sig = extract_request_signature(headers);
+    let timestamp = extract_request_timestamp(headers);
 
-    Ok(())
+    match state
+        .relay_read_data(
+            content_id,
+            version,
+            &token,
+            request_sig.as_deref(),
+            timestamp,
+        )
+        .await
+    {
+        Ok((data, served_version)) => {
+            let encoded = base64::engine::general_purpose::STANDARD.encode(&data);
+            Json(ContentDataResponse {
+                content_id: content_id.to_string(),
+                data: encoded,
+                version: Some(served_version),
+            })
+            .into_response()
+        }
+        Err(e) => e.into_response(),
+    }
+}
+
+/// History counterpart of [`relay_read_data_response`].
+async fn relay_read_history_response(
+    state: &AppState,
+    headers: &HeaderMap,
+    content_id: &str,
+) -> Response {
+    let Some(token) = extract_auth_token(headers) else {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(ErrorResponse {
+                error: "Authorization header is required".to_string(),
+            }),
+        )
+            .into_response();
+    };
+    let request_sig = extract_request_signature(headers);
+    let timestamp = extract_request_timestamp(headers);
+
+    match state
+        .relay_read_history(content_id, &token, request_sig.as_deref(), timestamp)
+        .await
+    {
+        Ok(versions) => Json(ContentHistoryResponse {
+            content_id: content_id.to_string(),
+            versions,
+        })
+        .into_response(),
+        Err(e) => e.into_response(),
+    }
 }
 
 /// Get content data from CRDT repository.
@@ -684,11 +702,14 @@ async fn get_content_data(
     headers: HeaderMap,
     Query(query): Query<VersionQuery>,
 ) -> impl IntoResponse {
-    // Bug #93: if this node holds no local state for the content (it is neither
-    // the creator nor a member), pull it from a member first so the read below
-    // and the access-policy check both see the real data. Best-effort: on
-    // failure we fall through to the normal local read (which 404s as before).
-    let _ = state.ensure_content_local(&content_id).await;
+    // Bug #93: this node may not replicate the content (it is neither the
+    // creator nor a member). Relay the read — auth material included — to a
+    // member node, which re-authenticates the caller against the real access
+    // policy and serves the data. Operations are never pulled to this node.
+    if !state.has_local_content(&content_id).await {
+        return relay_read_data_response(&state, &headers, &content_id, query.version.as_deref())
+            .await;
+    }
 
     if let Err(response) = verify_read_access(&state, &headers, &content_id).await {
         return response;
@@ -741,8 +762,10 @@ async fn get_content_history(
     Path(content_id): Path<String>,
     headers: HeaderMap,
 ) -> impl IntoResponse {
-    // Bug #93: pull content from a member if we hold none locally (best-effort).
-    let _ = state.ensure_content_local(&content_id).await;
+    // Bug #93: relay the read to a member when we don't replicate the content.
+    if !state.has_local_content(&content_id).await {
+        return relay_read_history_response(&state, &headers, &content_id).await;
+    }
 
     if let Err(response) = verify_read_access(&state, &headers, &content_id).await {
         return response;
@@ -777,8 +800,10 @@ async fn get_content_version(
     Path((content_id, version)): Path<(String, String)>,
     headers: HeaderMap,
 ) -> impl IntoResponse {
-    // Bug #93: pull content from a member if we hold none locally (best-effort).
-    let _ = state.ensure_content_local(&content_id).await;
+    // Bug #93: relay the read to a member when we don't replicate the content.
+    if !state.has_local_content(&content_id).await {
+        return relay_read_data_response(&state, &headers, &content_id, Some(&version)).await;
+    }
 
     if let Err(response) = verify_read_access(&state, &headers, &content_id).await {
         return response;

--- a/monas-state-node/src/test_utils.rs
+++ b/monas-state-node/src/test_utils.rs
@@ -265,6 +265,29 @@ impl PeerNetwork for MockPeerNetwork {
             .unwrap_or(true))
     }
 
+    async fn relay_read_content(
+        &self,
+        _peer_id: &str,
+        content_id: &str,
+        _version: Option<&str>,
+        _auth_token: &str,
+        _request_signature: &[u8],
+        _timestamp: Option<u64>,
+    ) -> Result<(Vec<u8>, String)> {
+        Err(anyhow::anyhow!("Content not found: {}", content_id))
+    }
+
+    async fn relay_read_history(
+        &self,
+        _peer_id: &str,
+        content_id: &str,
+        _auth_token: &str,
+        _request_signature: &[u8],
+        _timestamp: Option<u64>,
+    ) -> Result<Vec<String>> {
+        Err(anyhow::anyhow!("Content not found: {}", content_id))
+    }
+
     async fn connected_peer_count(&self) -> usize {
         0
     }

--- a/monas-state-node/src/test_utils.rs
+++ b/monas-state-node/src/test_utils.rs
@@ -9,7 +9,7 @@ use crate::domain::events::Event;
 use crate::domain::state_node::NodeSnapshot;
 use crate::port::content_repository::{CommitResult, ContentRepository, SerializedOperation};
 use crate::port::event_publisher::EventPublisher;
-use crate::port::peer_network::PeerNetwork;
+use crate::port::peer_network::{PeerNetwork, RelayReadError, RelayReadErrorKind};
 use crate::port::persistence::{PersistentContentRepository, PersistentNodeRegistry};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -23,6 +23,9 @@ use tokio::sync::Mutex;
 
 /// Type alias for published events storage.
 pub type PublishedEvents = Arc<Mutex<Vec<(String, Vec<u8>)>>>;
+
+/// Configurable result of a mocked relayed data read: `(data, version)`.
+pub type MockRelayReadData = Arc<Mutex<Option<(Vec<u8>, String)>>>;
 
 /// Mock implementation of PeerNetwork for testing.
 #[derive(Default)]
@@ -47,6 +50,18 @@ pub struct MockPeerNetwork {
     pub relay_update_peers: Arc<Mutex<Vec<String>>>,
     pub relay_delete_peers: Arc<Mutex<Vec<String>>>,
     pub relay_invalidate_tokens_peers: Arc<Mutex<Vec<String>>>,
+    /// When `Some`, relayed data reads succeed with this payload; when `None`
+    /// they fail with a typed NotFound verdict (the common test default).
+    pub relay_read_data_result: MockRelayReadData,
+    /// Same, for relayed history reads.
+    pub relay_read_history_result: Arc<Mutex<Option<Vec<String>>>>,
+    /// When `Some`, relayed data reads fail with exactly this typed error
+    /// (takes precedence over `relay_read_data_result`).
+    pub relay_read_data_error: Arc<Mutex<Option<RelayReadError>>>,
+    /// `since_version` argument of each `fetch_operations` call, in order.
+    /// Lets tests assert whether a sync requested the full history
+    /// (`None`) or an incremental fetch (`Some(version)`).
+    pub fetch_operations_since: Arc<Mutex<Vec<Option<String>>>>,
 }
 
 impl MockPeerNetwork {
@@ -68,6 +83,31 @@ impl MockPeerNetwork {
             relay_update_peers: Arc::new(Mutex::new(Vec::new())),
             relay_delete_peers: Arc::new(Mutex::new(Vec::new())),
             relay_invalidate_tokens_peers: Arc::new(Mutex::new(Vec::new())),
+            relay_read_data_result: Arc::new(Mutex::new(None)),
+            relay_read_history_result: Arc::new(Mutex::new(None)),
+            relay_read_data_error: Arc::new(Mutex::new(None)),
+            fetch_operations_since: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    pub fn with_relay_read_error(self, error: RelayReadError) -> Self {
+        Self {
+            relay_read_data_error: Arc::new(Mutex::new(Some(error))),
+            ..self
+        }
+    }
+
+    pub fn with_relay_read_data(self, data: Vec<u8>, version: &str) -> Self {
+        Self {
+            relay_read_data_result: Arc::new(Mutex::new(Some((data, version.to_string())))),
+            ..self
+        }
+    }
+
+    pub fn with_relay_read_history(self, versions: Vec<String>) -> Self {
+        Self {
+            relay_read_history_result: Arc::new(Mutex::new(Some(versions))),
+            ..self
         }
     }
 
@@ -176,8 +216,12 @@ impl PeerNetwork for MockPeerNetwork {
         &self,
         _peer_id: &str,
         _genesis_cid: &str,
-        _since_version: Option<&str>,
+        since_version: Option<&str>,
     ) -> Result<Vec<SerializedOperation>> {
+        self.fetch_operations_since
+            .lock()
+            .await
+            .push(since_version.map(ToOwned::to_owned));
         Ok(self.fetched_operations.lock().await.clone())
     }
 
@@ -273,8 +317,17 @@ impl PeerNetwork for MockPeerNetwork {
         _auth_token: &str,
         _request_signature: &[u8],
         _timestamp: Option<u64>,
-    ) -> Result<(Vec<u8>, String)> {
-        Err(anyhow::anyhow!("Content not found: {}", content_id))
+    ) -> std::result::Result<(Vec<u8>, String), RelayReadError> {
+        if let Some(error) = self.relay_read_data_error.lock().await.clone() {
+            return Err(error);
+        }
+        match self.relay_read_data_result.lock().await.clone() {
+            Some(result) => Ok(result),
+            None => Err(RelayReadError {
+                kind: RelayReadErrorKind::NotFound,
+                message: format!("Content not found: {}", content_id),
+            }),
+        }
     }
 
     async fn relay_read_history(
@@ -284,8 +337,14 @@ impl PeerNetwork for MockPeerNetwork {
         _auth_token: &str,
         _request_signature: &[u8],
         _timestamp: Option<u64>,
-    ) -> Result<Vec<String>> {
-        Err(anyhow::anyhow!("Content not found: {}", content_id))
+    ) -> std::result::Result<Vec<String>, RelayReadError> {
+        match self.relay_read_history_result.lock().await.clone() {
+            Some(versions) => Ok(versions),
+            None => Err(RelayReadError {
+                kind: RelayReadErrorKind::NotFound,
+                message: format!("Content not found: {}", content_id),
+            }),
+        }
     }
 
     async fn connected_peer_count(&self) -> usize {
@@ -345,6 +404,9 @@ pub struct MockContentRepository {
     pub operations: Arc<Mutex<Vec<SerializedOperation>>>,
     pub next_cid: Arc<Mutex<u64>>,
     pub access_policies: Arc<Mutex<HashMap<String, AccessPolicy>>>,
+    /// When true, `get_access_policy` fails — used to test that read
+    /// authorization fails closed on policy-store errors.
+    pub access_policy_error: Arc<Mutex<bool>>,
 }
 
 impl MockContentRepository {
@@ -355,6 +417,7 @@ impl MockContentRepository {
             operations: Arc::new(Mutex::new(Vec::new())),
             next_cid: Arc::new(Mutex::new(1)),
             access_policies: Arc::new(Mutex::new(HashMap::new())),
+            access_policy_error: Arc::new(Mutex::new(false)),
         }
     }
 }
@@ -438,14 +501,12 @@ impl ContentRepository for MockContentRepository {
         }
     }
 
-    async fn get_version(&self, version_cid: &str) -> Result<Option<Vec<u8>>> {
-        // For simplicity, return the first content that matches
+    async fn get_version(&self, genesis_cid: &str, version_cid: &str) -> Result<Option<Vec<u8>>> {
+        // Scoped to the given series, mirroring the real implementation.
         let contents = self.contents.lock().await;
-        for (genesis_cid, _) in contents.iter() {
-            if let Some(history) = self.history.lock().await.get(genesis_cid) {
-                if history.contains(&version_cid.to_string()) {
-                    return Ok(contents.get(genesis_cid).cloned());
-                }
+        if let Some(history) = self.history.lock().await.get(genesis_cid) {
+            if history.contains(&version_cid.to_string()) {
+                return Ok(contents.get(genesis_cid).cloned());
             }
         }
         Ok(None)
@@ -490,6 +551,9 @@ impl ContentRepository for MockContentRepository {
     }
 
     async fn get_access_policy(&self, genesis_cid: &str) -> Result<Option<AccessPolicy>> {
+        if *self.access_policy_error.lock().await {
+            return Err(anyhow::anyhow!("policy store unavailable"));
+        }
         Ok(self.access_policies.lock().await.get(genesis_cid).cloned())
     }
 


### PR DESCRIPTION
## Summary

Fixes the read path for content a gateway-facing node does not replicate (bug #93 follow-up). After #53, write placement picks members by capacity/XOR distance, so the node the gateway talks to is often **not** a member of a content network. Writes relay correctly, but reads were broken in three stacked ways — found while E2E-testing the Drive UI (#47) against the 4-node AWS deployment:

1. **`/state/*` reads always 401'd.** The SDK signs write requests itself via monas-account (`Authorization: user:<hex>` + P-256 signature), but forwarded the caller's (empty) auth headers for reads. → The SDK now signs `read:content:<timestamp>` via the account for `get_latest_version` / `get_history` / `verify_integrity`, exactly like the write path. Explicit caller Authorization is still passed through.

2. **Phantom history defeated local-presence checks.** crsl-lib's `linear_history(genesis)` returns `[genesis]` even when the node holds nothing, so `ensure_content_local` never pulled, and `sync_from_peers` requested ops `since=genesis` — which providers answer by *skipping the Create operation*, so a member that missed the initial push synced "0 operations from 2 providers" forever (observed on node4). → Both now gate on `has_genesis` (actual DAG node lookup).

3. **Non-member reads had no authorized path.** `ensure_content_local` pulled ops via the read-only `FetchOperations` RPC, but members (correctly) reject that pull for non-members — the two #93-era fixes contradicted each other. Rather than dropping the membership gate, this implements the hardened read-relay the old SECURITY NOTE planned:
   - New `ReadContent` / `ReadHistory` relay RPCs carry the original caller's token, request signature and timestamp.
   - The **member** re-authenticates the caller and enforces the access policy (`StateNodeService::authorize_read`, now shared with the HTTP read path) before serving data / version / history.
   - Read endpoints relay when `has_genesis` is false; `ensure_content_local` is removed. Operations are never copied to non-members, and `FetchOperations` keeps its membership gate.
   - Member verdicts map back to typed errors so the relaying node returns the member's 401/403/404.

## Verification

- `cargo test -p monas-state-node`: 294 unit + 5 e2e multi-node + 32 integration + 4 public-key + 2 push-race — all green.
- `cargo test -p monas-sdk --test state_controller_integration_test`: 10/10.
- Deployed to the 4-node AWS environment and verified end-to-end through the Drive UI (#47) with Playwright: create-in-folder (the old 408 repro), preview with version history, **verify-integrity via relayed version read on a non-member node**, edit, HPKE share/revoke, delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Deep-review round 1 fixes (`207f0af`)

- **Typed relay verdicts**: relayed-read failures cross the wire as `ContentResponse::ReadFailed { kind, message }` (`RelayReadErrorKind` in the port layer) — no more substring matching on stringified errors. Member auth verdicts (401/403) short-circuit the member loop so a later member's transport failure can't overwrite them.
- **`authorize_read` fails closed**: a policy-store error now denies instead of falling through to the no-policy allow.
- **`get_version` scoped to the content series**: the version CID must belong to the authorized content's DAG, closing a cross-content version read (applied to local and relayed paths).
- **In-repo tests** for the previously E2E-only paths: relay-read happy path, typed 403 mapping, `authorize_read` owner/no-policy/deny/fail-closed, phantom-history sync gating, cross-content `get_version` rejection, `fetch_encrypted` contract, revoke-by-`remote_content_id`.

Note on `edd429f` (also in this PR): it adds two public SDK API fields — `VerifyIntegrityInput.local_content_id` (verify against the locally stored ciphertext; the state node never sees plaintext) and `RevokeShareInput.remote_content_id` (the state node only knows the series id). Both optional, backward compatible.
